### PR TITLE
FIX: CMake VSCode IDE integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
     "-DCMAKE_TOOLCHAIN_FILE:STRING=${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
     "-DSTONEYVCV_BUILD_TESTS:BOOL=TRUE",
     "--no-warn-unused-cli",
-    "--compile-no-warn-as-error",
+    "--compile-no-warning-as-error",
     "-Wno-dev"
   ],
   "cmake.sourceDirectory": "${workspaceFolder}",


### PR DESCRIPTION
## What kind of change does this PR introduce?

CMake Tools IDE integration is failing to configure the project, due to a faulty arg being specified in `.vscode/settings.json`. The word `warn` should be the *gerund*, `warning`, in `--compile-no-warning-as-error`.

## What is the current behavior?

CMake IDE integration failing.

## What is the new behavior?

CMake IDE integration fixed.

