### PR TITLE
module/HP4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,40 +170,40 @@ if(STONEYVCV_BUILD_MODULES)
 
 #[==[HP1]==]
 if(STONEYVCV_BUILD_MODULE_HP1)
-set(STONEYVCV_HP1_HPP "HP1.hpp")
-configure_file("include/${STONEYVCV_HP1_HPP}" "include/${STONEYVCV_HP1_HPP}")
-target_sources(StoneyVCV
-    PUBLIC
-    FILE_SET stoneyvcv_PUBLIC_HEADERS
-    TYPE HEADERS
-    BASE_DIRS
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    FILES
-    #[==[include/plugin.hpp]==]
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP1_HPP}>
-    $<INSTALL_INTERFACE:include/${STONEYVCV_HP1_HPP}>
-)
-target_sources(StoneyVCV PRIVATE "src/HP1.cpp")
+    set(STONEYVCV_HP1_HPP "HP1.hpp")
+    configure_file("include/${STONEYVCV_HP1_HPP}" "include/${STONEYVCV_HP1_HPP}")
+    target_sources(StoneyVCV
+        PUBLIC
+        FILE_SET stoneyvcv_PUBLIC_HEADERS
+        TYPE HEADERS
+        BASE_DIRS
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        FILES
+        #[==[include/plugin.hpp]==]
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP1_HPP}>
+        $<INSTALL_INTERFACE:include/${STONEYVCV_HP1_HPP}>
+    )
+    target_sources(StoneyVCV PRIVATE "src/HP1.cpp")
 endif(STONEYVCV_BUILD_MODULE_HP1)
 
 #[==[HP2]==]
 if(STONEYVCV_BUILD_MODULE_HP2)
-set(STONEYVCV_HP2_HPP "HP2.hpp")
-configure_file("include/${STONEYVCV_HP2_HPP}" "include/${STONEYVCV_HP2_HPP}")
-target_sources(StoneyVCV
-    PUBLIC
-    FILE_SET stoneyvcv_PUBLIC_HEADERS
-    TYPE HEADERS
-    BASE_DIRS
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    FILES
-    #[==[include/plugin.hpp]==]
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP2_HPP}>
-    $<INSTALL_INTERFACE:include/${STONEYVCV_HP2_HPP}>
-)
-target_sources(StoneyVCV PRIVATE "src/HP2.cpp")
+    set(STONEYVCV_HP2_HPP "HP2.hpp")
+    configure_file("include/${STONEYVCV_HP2_HPP}" "include/${STONEYVCV_HP2_HPP}")
+    target_sources(StoneyVCV
+        PUBLIC
+        FILE_SET stoneyvcv_PUBLIC_HEADERS
+        TYPE HEADERS
+        BASE_DIRS
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        FILES
+        #[==[include/plugin.hpp]==]
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP2_HPP}>
+        $<INSTALL_INTERFACE:include/${STONEYVCV_HP2_HPP}>
+    )
+    target_sources(StoneyVCV PRIVATE "src/HP2.cpp")
 endif(STONEYVCV_BUILD_MODULE_HP2)
 
 #[==[HP4]==]
@@ -227,6 +227,47 @@ endif(STONEYVCV_BUILD_MODULE_HP4)
 
 endif(STONEYVCV_BUILD_MODULES)
 
+# set(CMAKE_VERBOSE_MAKEFILE TRUE CACHE BOOL "" FORCE)
+# set(CMAKE_AUTOGEN_VERBOSE TRUE CACHE BOOL "" FORCE)
+
+# #[==[plugin]==]
+# add_custom_target(plugin ALL
+# COMMAND "make"
+# WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+# BYPRODUCTS
+# "${PROJECT_SOURCE_DIR}/${PLUGIN_LIB}"
+# SOURCES
+# "${PROJECT_SOURCE_DIR}/src/${PLUGIN_CPP}"
+# "${PROJECT_BINARY_DIR}/include/${PLUGIN_HPP}"
+# JOB_SERVER_AWARE TRUE
+# DEPENDS StoneyVCV
+# USES_TERMINAL
+# )
+
+# #[==[dist]==]
+# add_custom_target(dist
+# COMMAND "make" "dist"
+# WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+# BYPRODUCTS
+# "${PROJECT_SOURCE_DIR}/dist"
+# SOURCES
+# "${PROJECT_SOURCE_DIR}/${PLUGIN_LIB}"
+# JOB_SERVER_AWARE TRUE
+# DEPENDS plugin
+# USES_TERMINAL
+# )
+
+#[==[clean]==] # Not supported...
+# add_custom_target(clean
+# COMMAND "make" "clean"
+# WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+# BYPRODUCTS "${PROJECT_SOURCE_DIR}/${PLUGIN_LIB}"
+# SOURCES
+# "${PROJECT_SOURCE_DIR}/src/${PLUGIN_CPP}"
+# "${PROJECT_BINARY_DIR}/include/${PLUGIN_HPP}"
+# JOB_SERVER_AWARE TRUE
+# USES_TERMINAL
+# )
 
 # # Only build tests if this project is the top-level project...
 #[==[Tests_StoneyVCV]==]
@@ -245,9 +286,7 @@ if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
     target_sources(Tests_StoneyVCV
         PRIVATE
         "${PROJECT_SOURCE_DIR}/test/plugin.cpp"
-        "${PROJECT_SOURCE_DIR}/test/HP1.cpp"
     )
-
     target_link_libraries(Tests_StoneyVCV
         PRIVATE
         rack::lib
@@ -261,6 +300,24 @@ if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
     )
     target_compile_features(Tests_StoneyVCV PUBLIC cxx_std_17)
     target_compile_features(Tests_StoneyVCV PUBLIC c_std_17)
+    if(STONEYVCV_BUILD_MODULE_HP4)
+        target_sources(Tests_StoneyVCV
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP4.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP4)
+    if(STONEYVCV_BUILD_MODULE_HP2)
+        target_sources(Tests_StoneyVCV
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP2.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP2)
+    if(STONEYVCV_BUILD_MODULE_HP1)
+        target_sources(Tests_StoneyVCV
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP1.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP1)
 
     enable_testing()
 

--- a/include/plugin.hpp
+++ b/include/plugin.hpp
@@ -67,6 +67,11 @@ extern ::rack::plugin::Plugin* pluginInstance;
     #warning "No modules found..."
 #endif
 
+namespace Panels {
+extern ::NVGcolor bgBlack;
+extern ::NVGcolor bgWhite;
+}
+
 //==============================================================================
 
 } // namespace StoneyVCV

--- a/res/HP4-dark.svg
+++ b/res/HP4-dark.svg
@@ -53,7 +53,7 @@
      inkscape:cx="36.870568"
      inkscape:cy="191.42391"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="layer2"
      showgrid="false"
      units="mm"
      inkscape:snap-bbox="true"
@@ -84,7 +84,8 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-168.49998)">
+     transform="translate(0,-168.49998)"
+     style="display:inline">
     <rect
        style="display:inline;opacity:1;vector-effect:none;fill:#2b2b2b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.530199;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
        id="rect828"
@@ -105,5 +106,14 @@
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="components"
-     style="display:none" />
+     style="display:none">
+    <rect
+       style="display:none;fill:#ffff00;fill-rule:evenodd;stroke-width:0.264583"
+       id="rect1300"
+       height="128.5"
+       x="-0.32782277"
+       y="0.20045215"
+       width="0"
+       inkscape:label="widget" />
+  </g>
 </svg>

--- a/res/HP4-light.svg
+++ b/res/HP4-light.svg
@@ -53,7 +53,7 @@
      inkscape:cx="36.870568"
      inkscape:cy="243.95184"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="layer2"
      showgrid="false"
      units="mm"
      inkscape:snap-bbox="true"
@@ -84,7 +84,8 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-168.49998)">
+     transform="translate(0,-168.49998)"
+     style="display:inline">
     <rect
        style="display:inline;opacity:1;vector-effect:none;fill:#ebebeb;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.530199;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
        id="rect1138"
@@ -105,5 +106,14 @@
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="components"
-     style="display:none" />
+     style="display:none">
+    <rect
+       style="display:none;fill:#ffff00;fill-rule:evenodd;stroke-width:0.264583"
+       id="rect879"
+       height="128.5"
+       x="0.06472934"
+       y="0.67339391"
+       width="0"
+       inkscape:label="widget" />
+  </g>
 </svg>

--- a/src/HP4.cpp
+++ b/src/HP4.cpp
@@ -76,9 +76,13 @@ void ::StoneyDSP::StoneyVCV::HP4Widget::step()
 
 void ::StoneyDSP::StoneyVCV::HP4Widget::draw(const ::StoneyDSP::StoneyVCV::Widget::DrawArgs &args)
 {
+    NVGcolor bgBlack = ::StoneyDSP::StoneyVCV::Panels::bgBlack;
+    NVGcolor bgWhite = ::StoneyDSP::StoneyVCV::Panels::bgWhite;
+
+    //
     ::nvgBeginPath(args.vg);
     ::nvgRect(args.vg, 0.0, 0.0, box.size.x, box.size.y);
-    ::NVGcolor bg = ::rack::settings::preferDarkPanels ? ::nvgRGB(42, 42, 42) : ::nvgRGB(235, 235, 235);
+    ::NVGcolor bg = ::rack::settings::preferDarkPanels ? bgBlack : bgWhite;
     ::nvgFillColor(args.vg, bg);
     ::nvgFill(args.vg);
     ::StoneyDSP::StoneyVCV::Widget::draw(args);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -67,3 +67,12 @@ void init(::rack::plugin::Plugin* p) {
     // As an alternative, consider lazy-loading assets and lookup tables when
     // your module is created to reduce startup times of Rack.
 }
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+namespace Panels {
+::NVGcolor bgBlack = ::nvgRGBA(42, 42, 42, 255);
+::NVGcolor bgWhite = ::nvgRGBA(235, 235, 235, 255);
+}
+}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small changes for HP4 module - use global bg color vars...

Added missing test files to the tests executable target's sources, wrapped in corresponding option definitions (a functional approach constructing a `list` and a `foreach(IN LISTS)` would be good here...)

More tests are needed - but, we only really need to test the methods which we override from the base structs, as well as any customary methods. No need to test the underlying VCVRack struct methods for default behaviour.

## What is the current behavior?

Some missing test cases. No beginning of design system.

## What is the new behavior?

Test cases for all three `HP<x>` modules are now registered.