### PR TITLE
module/hp2

### DIFF
--- a/test/HP2.cpp
+++ b/test/HP2.cpp
@@ -29,29 +29,65 @@
  *
  ******************************************************************************/
 
+#if (STONEYVCV_BUILD_HP2 == 1) && (STONEYVCV_BUILD_TESTS == 1)
+
 #include <catch2/catch_test_macros.hpp>
+// for floating point comparisons
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "HP2.hpp"
+
+// Spec goes here...
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+struct HP2Spec final {
+public:
+    std::string slug;
+    static constexpr int NUM_PARAMS = 0;
+    static constexpr int NUM_INPUTS = 0;
+    static constexpr int NUM_OUTPUTS = 0;
+    static constexpr int NUM_LIGHTS = 0;
+    HP4Spec() : slug("HP2") {};
+private:
+    // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP2Spec)
+    STONEYDSP_DECLARE_NON_COPYABLE(HP2Spec)
+    STONEYDSP_DECLARE_NON_MOVEABLE(HP2Spec)
+};
+}
+}
 
 // Tests go here...
 
 TEST_CASE("HP2", "[HP2]") {
 
+    std::shared_ptr<::StoneyDSP::StoneyVCV::HP2Spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP2Spec>();
+
     SECTION("files") {
         REQUIRE(STONEYVCV_HP2_HPP_INCLUDED == 1);
     }
-
-    SECTION("instance") {
-        REQUIRE(::StoneyDSP::StoneyVCV::modelHP2 != nullptr);
-    }
-
     SECTION("HP2Module") {
-        SECTION("properties") {
+        SECTION("statics") {
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::PARAMS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::INPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::OUTPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::LIGHTS_LEN == 0);
         }
+        SECTION( "methods" ) {
+            ::StoneyDSP::StoneyVCV::HP2Module* test_hp2Module = new ::StoneyDSP::StoneyVCV::HP2Module;
+            REQUIRE( test_hp2Module->getNumParams() == spec.get()->NUM_PARAMS );
+            REQUIRE( test_hp2Module->getNumInputs() == spec.get()->NUM_INPUTS );
+            REQUIRE( test_hp2Module->getNumOutputs() == spec.get()->NUM_OUTPUTS );
+            REQUIRE( test_hp2Module->getNumLights() == spec.get()->NUM_LIGHTS );
+            delete test_hp2Module;
+        }
+    }
+    SECTION( "instance" ) {
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP2 != nullptr );
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP2->slug == spec.get()->slug );
     }
 
+    spec.reset();
 }
+
+#endif

--- a/test/HP2.cpp
+++ b/test/HP2.cpp
@@ -48,7 +48,7 @@ public:
     static constexpr int NUM_INPUTS = 0;
     static constexpr int NUM_OUTPUTS = 0;
     static constexpr int NUM_LIGHTS = 0;
-    HP4Spec() : slug("HP2") {};
+    HP2Spec() : slug("HP2") {};
 private:
     // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP2Spec)
     STONEYDSP_DECLARE_NON_COPYABLE(HP2Spec)


### PR DESCRIPTION
## What kind of change does this PR introduce?

- adds a preprocessor macro toggle to the tests file, so that users who are not engaging with the unit testing are not confronted with an IDE filled with red squiggles when browsing the project files
