### PR TITLE
tests/spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ if(STONEYVCV_BUILD_MODULE_HP1)
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP1_HPP}>
     )
     target_sources(StoneyVCV PRIVATE "src/HP1.cpp")
+    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP1=1")
 endif(STONEYVCV_BUILD_MODULE_HP1)
 
 #[==[HP2]==]
@@ -204,6 +205,7 @@ if(STONEYVCV_BUILD_MODULE_HP2)
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP2_HPP}>
     )
     target_sources(StoneyVCV PRIVATE "src/HP2.cpp")
+    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP2=1")
 endif(STONEYVCV_BUILD_MODULE_HP2)
 
 #[==[HP4]==]
@@ -223,6 +225,7 @@ if(STONEYVCV_BUILD_MODULE_HP4)
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP4_HPP}>
     )
     target_sources(StoneyVCV PRIVATE "src/HP4.cpp")
+    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP4=1")
 endif(STONEYVCV_BUILD_MODULE_HP4)
 
 endif(STONEYVCV_BUILD_MODULES)
@@ -272,6 +275,9 @@ endif(STONEYVCV_BUILD_MODULES)
 # # Only build tests if this project is the top-level project...
 #[==[Tests_StoneyVCV]==]
 if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+
+    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_TESTS=1")
+
     find_package(Catch2 3.5.2 REQUIRED)
 
     # # These tests can use the Catch2-provided main

--- a/test/HP1.cpp
+++ b/test/HP1.cpp
@@ -29,29 +29,66 @@
  *
  ******************************************************************************/
 
+#if (STONEYVCV_BUILD_HP1 == 1) && (STONEYVCV_BUILD_TESTS == 1)
+
 #include <catch2/catch_test_macros.hpp>
+// for floating point comparisons
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "HP1.hpp"
+
+// Spec goes here...
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+struct HP1Spec final {
+public:
+    std::string slug;
+    static constexpr int NUM_PARAMS = 0;
+    static constexpr int NUM_INPUTS = 0;
+    static constexpr int NUM_OUTPUTS = 0;
+    static constexpr int NUM_LIGHTS = 0;
+    HP1Spec() : slug("HP1") {};
+private:
+    // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP1Spec)
+    STONEYDSP_DECLARE_NON_COPYABLE(HP1Spec)
+    STONEYDSP_DECLARE_NON_MOVEABLE(HP1Spec)
+};
+}
+}
 
 // Tests go here...
 
 TEST_CASE("HP1", "[HP1]") {
 
+    std::shared_ptr<::StoneyDSP::StoneyVCV::HP1spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP1Spec>();
+
     SECTION("files") {
         REQUIRE(STONEYVCV_HP1_HPP_INCLUDED == 1);
     }
-
-    SECTION("instance") {
-        REQUIRE(::StoneyDSP::StoneyVCV::modelHP1 != nullptr);
-    }
-
     SECTION("HP1Module") {
-        SECTION("properties") {
+        SECTION("statics") {
             REQUIRE(::StoneyDSP::StoneyVCV::HP1Module::PARAMS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP1Module::INPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP1Module::OUTPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP1Module::LIGHTS_LEN == 0);
         }
+        SECTION( "methods" ) {
+            ::StoneyDSP::StoneyVCV::HP1Module* test_hp1Module = new ::StoneyDSP::StoneyVCV::HP1Module;
+            REQUIRE( test_hp1Module->getNumParams() == spec.get()->NUM_PARAMS );
+            REQUIRE( test_hp1Module->getNumInputs() == spec.get()->NUM_INPUTS );
+            REQUIRE( test_hp1Module->getNumOutputs() == spec.get()->NUM_OUTPUTS );
+            REQUIRE( test_hp1Module->getNumLights() == spec.get()->NUM_LIGHTS );
+            delete test_hp1Module;
+        }
+    }
+    SECTION("instance") {
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP1 != nullptr );
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP1->slug == spec.get()->slug );
     }
 
+    spec.reset();
+
 }
+
+#endif

--- a/test/HP1.cpp
+++ b/test/HP1.cpp
@@ -61,7 +61,7 @@ private:
 
 TEST_CASE("HP1", "[HP1]") {
 
-    std::shared_ptr<::StoneyDSP::StoneyVCV::HP1spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP1Spec>();
+    std::shared_ptr<::StoneyDSP::StoneyVCV::HP1Spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP1Spec>();
 
     SECTION("files") {
         REQUIRE(STONEYVCV_HP1_HPP_INCLUDED == 1);

--- a/test/HP2.cpp
+++ b/test/HP2.cpp
@@ -29,29 +29,65 @@
  *
  ******************************************************************************/
 
+#if (STONEYVCV_BUILD_HP2 == 1) && (STONEYVCV_BUILD_TESTS == 1)
+
 #include <catch2/catch_test_macros.hpp>
+// for floating point comparisons
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 #include "HP2.hpp"
+
+// Spec goes here...
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+struct HP2Spec final {
+public:
+    std::string slug;
+    static constexpr int NUM_PARAMS = 0;
+    static constexpr int NUM_INPUTS = 0;
+    static constexpr int NUM_OUTPUTS = 0;
+    static constexpr int NUM_LIGHTS = 0;
+    HP4Spec() : slug("HP2") {};
+private:
+    // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP2Spec)
+    STONEYDSP_DECLARE_NON_COPYABLE(HP2Spec)
+    STONEYDSP_DECLARE_NON_MOVEABLE(HP2Spec)
+};
+}
+}
 
 // Tests go here...
 
 TEST_CASE("HP2", "[HP2]") {
 
+    std::shared_ptr<::StoneyDSP::StoneyVCV::HP2Spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP2Spec>();
+
     SECTION("files") {
         REQUIRE(STONEYVCV_HP2_HPP_INCLUDED == 1);
     }
-
-    SECTION("instance") {
-        REQUIRE(::StoneyDSP::StoneyVCV::modelHP2 != nullptr);
-    }
-
     SECTION("HP2Module") {
-        SECTION("properties") {
+        SECTION("statics") {
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::PARAMS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::INPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::OUTPUTS_LEN == 0);
             REQUIRE(::StoneyDSP::StoneyVCV::HP2Module::LIGHTS_LEN == 0);
         }
+        SECTION( "methods" ) {
+            ::StoneyDSP::StoneyVCV::HP2Module* test_hp2Module = new ::StoneyDSP::StoneyVCV::HP2Module;
+            REQUIRE( test_hp2Module->getNumParams() == spec.get()->NUM_PARAMS );
+            REQUIRE( test_hp2Module->getNumInputs() == spec.get()->NUM_INPUTS );
+            REQUIRE( test_hp2Module->getNumOutputs() == spec.get()->NUM_OUTPUTS );
+            REQUIRE( test_hp2Module->getNumLights() == spec.get()->NUM_LIGHTS );
+            delete test_hp2Module;
+        }
+    }
+    SECTION( "instance" ) {
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP2 != nullptr );
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP2->slug == spec.get()->slug );
     }
 
+    spec.reset();
 }
+
+#endif

--- a/test/HP2.cpp
+++ b/test/HP2.cpp
@@ -48,7 +48,7 @@ public:
     static constexpr int NUM_INPUTS = 0;
     static constexpr int NUM_OUTPUTS = 0;
     static constexpr int NUM_LIGHTS = 0;
-    HP4Spec() : slug("HP2") {};
+    HP2Spec() : slug("HP2") {};
 private:
     // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP2Spec)
     STONEYDSP_DECLARE_NON_COPYABLE(HP2Spec)

--- a/test/HP4.cpp
+++ b/test/HP4.cpp
@@ -29,29 +29,66 @@
  *
  ******************************************************************************/
 
+#if (STONEYVCV_BUILD_HP4 == 1) && (STONEYVCV_BUILD_TESTS == 1)
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "HP4.hpp"
 
+// Spec goes here...
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+struct HP4Spec {
+public:
+    std::string slug;
+    static constexpr int NUM_PARAMS = 0;
+    static constexpr int NUM_INPUTS = 0;
+    static constexpr int NUM_OUTPUTS = 0;
+    static constexpr int NUM_LIGHTS = 0;
+    HP4Spec() : slug("HP4") {};
+private:
+    // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(HP4Spec)
+    STONEYDSP_DECLARE_NON_COPYABLE(HP4Spec)
+    STONEYDSP_DECLARE_NON_MOVEABLE(HP4Spec)
+};
+}
+}
+
 // Tests go here...
 
-TEST_CASE("HP4", "[HP4]") {
+TEST_CASE( "HP4", "[HP4]" ) {
 
-    SECTION("files") {
-        REQUIRE(STONEYVCV_HP4_HPP_INCLUDED == 1);
+    std::shared_ptr<::StoneyDSP::StoneyVCV::HP4Spec> spec = std::make_shared<::StoneyDSP::StoneyVCV::HP4Spec>();
+
+    SECTION( "files" ) {
+        REQUIRE( STONEYVCV_HP4_HPP_INCLUDED == 1 );
     }
 
-    SECTION("instance") {
-        REQUIRE(::StoneyDSP::StoneyVCV::modelHP4 != nullptr);
-    }
-
-    SECTION("HP4Module") {
-        SECTION("properties") {
-            REQUIRE(::StoneyDSP::StoneyVCV::HP4Module::PARAMS_LEN == 0);
-            REQUIRE(::StoneyDSP::StoneyVCV::HP4Module::INPUTS_LEN == 0);
-            REQUIRE(::StoneyDSP::StoneyVCV::HP4Module::OUTPUTS_LEN == 0);
-            REQUIRE(::StoneyDSP::StoneyVCV::HP4Module::LIGHTS_LEN == 0);
+    SECTION( "HP4Module" ) {
+        SECTION( "statics" ) {
+            REQUIRE( ::StoneyDSP::StoneyVCV::HP4Module::PARAMS_LEN == spec.get()->NUM_PARAMS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::HP4Module::INPUTS_LEN == spec.get()->NUM_INPUTS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::HP4Module::OUTPUTS_LEN == spec.get()->NUM_OUTPUTS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::HP4Module::LIGHTS_LEN == spec.get()->NUM_LIGHTS );
+        }
+        SECTION( "methods" ) {
+            ::StoneyDSP::StoneyVCV::HP4Module* test_hp4Module = new ::StoneyDSP::StoneyVCV::HP4Module;
+            REQUIRE( test_hp4Module->getNumParams() == spec.get()->NUM_PARAMS );
+            REQUIRE( test_hp4Module->getNumInputs() == spec.get()->NUM_INPUTS );
+            REQUIRE( test_hp4Module->getNumOutputs() == spec.get()->NUM_OUTPUTS );
+            REQUIRE( test_hp4Module->getNumLights() == spec.get()->NUM_LIGHTS );
+            delete test_hp4Module;
         }
     }
 
+
+    SECTION( "instance" ) {
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP4 != nullptr );
+        REQUIRE( ::StoneyDSP::StoneyVCV::modelHP4->slug == spec.get()->slug );
+    }
+
+    spec.reset();
 }
+
+#endif


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a test spec struct (the beginnings of one) which can be used to define expected properties of a module for test runs. Could be worth making a base class of this and deriving from it once per test file, once more discovery about unit test requirements is complete.

Additionally added a preprocessor macro toggle to help users who are not interacting with the unit tests by preventing them from being faced with an IDE filled with red squiggles when perusing the project files.

## What is the current behavior?

No test specs; all checks are being defined inline, not very DRY... although probably more readable. Nonetheless, a single source of truth is best practice, here.

Test files are "noisy" in the IDE if only using the Makefile workflow (non-developer/contributor).

## What is the new behavior?

Unit tests have a rough spec which to test against.

Non-testing users will have a less "noisy" experience when perusing the project in their IDE.
