### PR TITLE
module/HP1

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
 
+      # REQUIREMENTS
+
     - name: Checkout StoneyVCV code
       uses: actions/checkout@v4
       with:
@@ -45,6 +47,8 @@ jobs:
     - name: Install VCV's macOS Deps
       run: |
         brew install git wget cmake autoconf automake libtool jq python zstd pkg-config sccache ninja tree
+
+      # DEVELOPER WORKFLOW
 
     - name: Deps
       uses: johnwason/vcpkg-action@v6
@@ -78,7 +82,7 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
-        --target Tests_StoneyVCV
+        --target tests
         -j3
 
     - name: Test
@@ -91,7 +95,7 @@ jobs:
         --verbose
         && cd ${{ github.workspace }}
 
-    # If tests succeeded; deploy plugin bundle
+      # DEPLOYMENT WORKFLOW
 
     - name: Fetch Rack SDK
       run: |

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
 
+      # REQUIREMENTS
+
     - name: Checkout StoneyVCV code
       uses: actions/checkout@v4
       with:
@@ -38,6 +40,8 @@ jobs:
     - name: Install VCV's Linux Deps
       run: |
         sudo apt-get update && sudo apt install unzip git gdb curl cmake libx11-dev libglu1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev zlib1g-dev libasound2-dev libgtk2.0-dev libgtk-3-dev libjack-jackd2-dev jq zstd libpulse-dev pkg-config ninja-build ccache tree
+
+      # DEVELOPER WORKFLOW
 
     - name: vcpkg install
       uses: johnwason/vcpkg-action@v6
@@ -71,7 +75,7 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
-        --target Tests_StoneyVCV
+        --target tests
         -j3
 
     - name: Test
@@ -84,7 +88,7 @@ jobs:
         --verbose
         && cd ${{ github.workspace }}
 
-    # If tests succeeded; deploy plugin bundle
+      # DEPLOYMENT WORKFLOW
 
     - name: Fetch Rack SDK
       run: |

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
 
+      # REQUIREMENTS
+
     - name: Checkout StoneyVCV code
       uses: actions/checkout@v4
       with:
@@ -43,10 +45,8 @@ jobs:
 
     - name: Install winget
       uses: Cyberboss/install-winget@v1
-      # with:
-      #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   wget_release_id: latest
 
+      # https://vcvrack.com/manual/Building#Setting-up-your-development-environment
     - name: Install VCVRack2Free
       run: winget install VCVRack.VCVRack --disable-interactivity --accept-source-agreements
 
@@ -79,6 +79,8 @@ jobs:
           mingw-w64-x86_64-pkgconf
           tree
           ninja
+
+      # DEVELOPER WORKFLOW
 
     - name: Deps
       uses: johnwason/vcpkg-action@v6
@@ -113,7 +115,7 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
-        --target Tests_StoneyVCV
+        --target tests
         -j3
 
     - name: Test
@@ -126,6 +128,8 @@ jobs:
         --output-on-failure
         --verbose
         && cd ..
+
+      # DEPLOYMENT WORKFLOW
 
     - name: Fetch Rack SDK
       shell: msys2 {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ enable_language(C)
 enable_language(CXX)
 
 include(CMakeDependentOption)
+include(GNUInstallDirs)
 
 set(STONEYVCV_VERSION_MAJOR "${CMAKE_PROJECT_VERSION_MAJOR}" CACHE STRING "" FORCE)
 set(STONEYVCV_VERSION_MINOR "${CMAKE_PROJECT_VERSION_MINOR}" CACHE STRING "" FORCE)
@@ -33,11 +34,14 @@ get_target_property(rack_implib_location rack::lib IMPORTED_LOCATION)
 set(STONEYVCV_TARGETS)
 
 #[==[StoneyVCV]==]
-add_library(StoneyVCV SHARED EXCLUDE_FROM_ALL)
-add_library(StoneyDSP::StoneyVCV ALIAS StoneyVCV)
+add_library(plugin SHARED EXCLUDE_FROM_ALL)
+add_library(StoneyVCV::plugin ALIAS plugin)
+add_library(StoneyDSP::StoneyVCV::plugin ALIAS plugin)
+# add_library(StoneyVCV SHARED EXCLUDE_FROM_ALL)
+# add_library(StoneyDSP::StoneyVCV ALIAS StoneyVCV)
 
-set_target_properties(StoneyVCV PROPERTIES VERSION 2.1.0)
-set_target_properties(StoneyVCV PROPERTIES SOVERSION 2.1.0)
+set_target_properties(plugin PROPERTIES VERSION 2.1.0)
+set_target_properties(plugin PROPERTIES SOVERSION 2.1.0)
 
 # Gather project files...
 set(PLUGIN_HPP "plugin.hpp")
@@ -50,19 +54,11 @@ elseif(UNIX AND NOT APPLE)
 else() # LINUX
     set(PLUGIN_LIB_FILE_EXTENSION ".so")
 endif(WIN32)
-
 set(PLUGIN_LIB "plugin${PLUGIN_LIB_FILE_EXTENSION}")
-
 configure_file("include/${PLUGIN_HPP}" "include/${PLUGIN_HPP}")
-
-target_include_directories(StoneyVCV
+target_sources(plugin
     PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-target_sources(StoneyVCV
-    PUBLIC
-    FILE_SET stoneyvcv_PUBLIC_HEADERS
+    FILE_SET stoneyvcv_PLUGIN_PUBLIC_HEADERS
     TYPE HEADERS
     BASE_DIRS
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
@@ -73,32 +69,32 @@ target_sources(StoneyVCV
     $<INSTALL_INTERFACE:include/${PLUGIN_HPP}>
 )
 
-target_sources(StoneyVCV
+target_sources(plugin
     PRIVATE
     "src/${PLUGIN_CPP}"
 )
 
-set_target_properties(StoneyVCV
+set_target_properties(plugin
     PROPERTIES
     PREFIX ""
     LIBRARY_OUTPUT_NAME "plugin"
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     # Compatible Interface
-    INTERFACE_StoneyVCV_MAJOR_VERSION ${STONEYVCV_VERSION_MAJOR}
-    INTERFACE_StoneyVCV_MINOR_VERSION ${STONEYVCV_VERSION_MINOR}
-    INTERFACE_StoneyVCV_PATCH_VERSION ${STONEYVCV_VERSION_PATCH}
+    INTERFACE_plugin_MAJOR_VERSION ${STONEYVCV_VERSION_MAJOR}
+    INTERFACE_plugin_MINOR_VERSION ${STONEYVCV_VERSION_MINOR}
+    INTERFACE_plugin_PATCH_VERSION ${STONEYVCV_VERSION_PATCH}
 )
-set_property(TARGET StoneyVCV APPEND PROPERTY
-    COMPATIBLE_INTERFACE_STRING INTERFACE_StoneyVCV_MAJOR_VERSION
+set_property(TARGET plugin APPEND PROPERTY
+    COMPATIBLE_INTERFACE_STRING INTERFACE_plugin_MAJOR_VERSION
 )
-set_property(TARGET StoneyVCV APPEND PROPERTY
-    COMPATIBLE_INTERFACE_STRING INTERFACE_StoneyVCV_MINOR_VERSION
+set_property(TARGET plugin APPEND PROPERTY
+    COMPATIBLE_INTERFACE_STRING INTERFACE_plugin_MINOR_VERSION
 )
-set_property(TARGET StoneyVCV APPEND PROPERTY
-    COMPATIBLE_INTERFACE_STRING INTERFACE_StoneyVCV_PATCH_VERSION
+set_property(TARGET plugin APPEND PROPERTY
+    COMPATIBLE_INTERFACE_STRING INTERFACE_plugin_PATCH_VERSION
 )
-target_compile_definitions(StoneyVCV
+target_compile_definitions(plugin
     PUBLIC
     "STONEYVCV_VERSION_MAJOR=${STONEYVCV_VERSION_MAJOR}"
     "STONEYVCV_VERSION_MINOR=${STONEYVCV_VERSION_MINOR}"
@@ -107,39 +103,38 @@ target_compile_definitions(StoneyVCV
     "STONEYVCV_VERSION=${STONEYVCV_VERSION}"
 )
 if(DEFINED STONEYVCV_EXPERIMENTAL)
-    target_compile_definitions(StoneyVCV
+    target_compile_definitions(plugin
         PUBLIC
         "STONEYVCV_EXPERIMENTAL=${STONEYVCV_EXPERIMENTAL}"
     )
 endif(DEFINED STONEYVCV_EXPERIMENTAL)
-target_link_libraries(StoneyVCV
+target_link_libraries(plugin
     PUBLIC
     rack::lib
     StoneyDSP::Core
     StoneyDSP::SIMD
     StoneyDSP::DSP
 )
+target_compile_options(plugin
+    PUBLIC
+    "-fPIC"
+)
 
-# target_link_options(StoneyVCV
-# PRIVATE
-# "-fPIC"
-# "-shared"
-# )
 if(UNIX)
     if(APPLE)
-        target_link_options(StoneyVCV
+        target_link_options(plugin
             PUBLIC
             "-undefined dynamic_lookup"
         )
     else() # If we're Linux... (assumes GCC, as per Rack)
-        target_compile_options(StoneyVCV
+        target_compile_options(plugin
             PUBLIC
 
             # # This prevents static variables in the DSO (dynamic shared
             # # object) from being preserved after dlclose().
             "-fno-gnu-unique"
         )
-        target_link_options(StoneyVCV
+        target_link_options(plugin
             PUBLIC
 
             # # This prevents static variables in the DSO (dynamic shared
@@ -160,21 +155,68 @@ if(UNIX)
 endif(UNIX)
 
 if(WIN32)
-    target_link_options(StoneyVCV
+    target_link_options(plugin
         PUBLIC
         "-static-libstdc++"
     )
 endif(WIN32)
+list(APPEND STONEYVCV_TARGETS plugin)
+
+#[==[test]==]
+if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+
+    target_compile_definitions(plugin PUBLIC "-DSTONEYVCV_BUILD_TESTS=1")
+
+    find_package(Catch2 3.5.2 REQUIRED)
+
+    # # These tests can use the Catch2-provided main
+    add_executable(tests)
+    add_executable(StoneyVCV::test ALIAS tests)
+    add_executable(StoneyDSP::StoneyVCV::test ALIAS tests)
+    target_include_directories(tests
+        PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    )
+    target_sources(tests
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/plugin.cpp"
+    )
+    target_link_libraries(tests
+        PRIVATE
+        rack::lib
+        StoneyDSP::StoneyVCV::plugin
+        Catch2::Catch2WithMain
+    )
+    set_target_properties(tests
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/test"
+        RUNTIME_OUTPUT_NAME "tests"
+    )
+    target_compile_features(tests PUBLIC cxx_std_17)
+    target_compile_features(tests PUBLIC c_std_17)
+    # list(APPEND STONEYVCV_TARGETS tests)
+endif()
 
 if(STONEYVCV_BUILD_MODULES)
 
+# TODO: This module creation stuff can clearly be functionised...
+# Would be nice to perhaps define some helper functions in the VCVRack CMake
+# files to make this process much more DRY... I have ideas.
+
 #[==[HP1]==]
 if(STONEYVCV_BUILD_MODULE_HP1)
+    add_library(HP1 OBJECT)
+    add_library(StoneyVCV::HP1 ALIAS HP1)
+    add_library(StoneyDSP::StoneyVCV::HP1 ALIAS HP1)
     set(STONEYVCV_HP1_HPP "HP1.hpp")
     configure_file("include/${STONEYVCV_HP1_HPP}" "include/${STONEYVCV_HP1_HPP}")
-    target_sources(StoneyVCV
+    set_target_properties(HP1 PROPERTIES VERSION 0.0.1)
+    set_target_properties(HP1 PROPERTIES SOVERSION 0.0.1)
+    target_sources(HP1 PRIVATE "src/HP1.cpp")
+    target_sources(HP1
         PUBLIC
-        FILE_SET stoneyvcv_PUBLIC_HEADERS
+        FILE_SET stoneyvcv_HP1_PUBLIC_HEADERS
         TYPE HEADERS
         BASE_DIRS
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
@@ -184,17 +226,41 @@ if(STONEYVCV_BUILD_MODULE_HP1)
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP1_HPP}>
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP1_HPP}>
     )
-    target_sources(StoneyVCV PRIVATE "src/HP1.cpp")
-    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP1=1")
+    target_compile_options(HP1
+        PUBLIC
+        "-fPIC"
+    )
+    target_compile_definitions(HP1
+        PUBLIC
+        "STONEYVCV_VERSION_MAJOR=${STONEYVCV_VERSION_MAJOR}"
+        "STONEYVCV_VERSION_MINOR=${STONEYVCV_VERSION_MINOR}"
+        "STONEYVCV_VERSION_PATCH=${STONEYVCV_VERSION_PATCH}"
+        "STONEYVCV_VERSION_TWEAK=${STONEYVCV_VERSION_TWEAK}"
+        "STONEYVCV_VERSION=${STONEYVCV_VERSION}"
+    )
+    target_link_libraries(HP1
+        PUBLIC
+        rack::lib
+        StoneyDSP::Core
+    )
+    target_link_libraries(plugin PUBLIC StoneyDSP::StoneyVCV::HP1)
+    target_compile_definitions(plugin PUBLIC "-DSTONEYVCV_BUILD_HP1=1")
+    list(APPEND STONEYVCV_TARGETS HP1)
 endif(STONEYVCV_BUILD_MODULE_HP1)
 
 #[==[HP2]==]
 if(STONEYVCV_BUILD_MODULE_HP2)
+    add_library(HP2 OBJECT)
+    add_library(StoneyVCV::HP2 ALIAS HP2)
+    add_library(StoneyDSP::StoneyVCV::HP2 ALIAS HP2)
+    set_target_properties(HP2 PROPERTIES VERSION 0.0.1)
+    set_target_properties(HP2 PROPERTIES SOVERSION 0.0.1)
     set(STONEYVCV_HP2_HPP "HP2.hpp")
     configure_file("include/${STONEYVCV_HP2_HPP}" "include/${STONEYVCV_HP2_HPP}")
-    target_sources(StoneyVCV
+    target_sources(HP2 PRIVATE "src/HP2.cpp")
+    target_sources(HP2
         PUBLIC
-        FILE_SET stoneyvcv_PUBLIC_HEADERS
+        FILE_SET stoneyvcv_HP2_PUBLIC_HEADERS
         TYPE HEADERS
         BASE_DIRS
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
@@ -204,17 +270,41 @@ if(STONEYVCV_BUILD_MODULE_HP2)
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP2_HPP}>
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP2_HPP}>
     )
-    target_sources(StoneyVCV PRIVATE "src/HP2.cpp")
-    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP2=1")
+    target_compile_options(HP2
+        PUBLIC
+        "-fPIC"
+    )
+    target_compile_definitions(HP2
+        PUBLIC
+        "STONEYVCV_VERSION_MAJOR=${STONEYVCV_VERSION_MAJOR}"
+        "STONEYVCV_VERSION_MINOR=${STONEYVCV_VERSION_MINOR}"
+        "STONEYVCV_VERSION_PATCH=${STONEYVCV_VERSION_PATCH}"
+        "STONEYVCV_VERSION_TWEAK=${STONEYVCV_VERSION_TWEAK}"
+        "STONEYVCV_VERSION=${STONEYVCV_VERSION}"
+    )
+    target_link_libraries(HP2
+        PUBLIC
+        rack::lib
+        StoneyDSP::Core
+    )
+    target_link_libraries(plugin PUBLIC StoneyDSP::StoneyVCV::HP2)
+    target_compile_definitions(plugin PUBLIC "-DSTONEYVCV_BUILD_HP2=1")
+    list(APPEND STONEYVCV_TARGETS HP2)
 endif(STONEYVCV_BUILD_MODULE_HP2)
 
 #[==[HP4]==]
 if(STONEYVCV_BUILD_MODULE_HP4)
+    add_library(HP4 OBJECT)
+    add_library(StoneyVCV::HP4 ALIAS HP4)
+    add_library(StoneyDSP::StoneyVCV::HP4 ALIAS HP4)
     set(STONEYVCV_HP4_HPP "HP4.hpp")
     configure_file("include/${STONEYVCV_HP4_HPP}" "include/${STONEYVCV_HP4_HPP}")
-    target_sources(StoneyVCV
+    set_target_properties(HP2 PROPERTIES VERSION 0.0.1)
+    set_target_properties(HP2 PROPERTIES SOVERSION 0.0.1)
+    target_sources(HP4 PRIVATE "src/HP4.cpp")
+    target_sources(HP4
         PUBLIC
-        FILE_SET stoneyvcv_PUBLIC_HEADERS
+        FILE_SET stoneyvcv_HP4_PUBLIC_HEADERS
         TYPE HEADERS
         BASE_DIRS
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
@@ -224,9 +314,48 @@ if(STONEYVCV_BUILD_MODULE_HP4)
         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${STONEYVCV_HP4_HPP}>
         $<INSTALL_INTERFACE:include/${STONEYVCV_HP4_HPP}>
     )
-    target_sources(StoneyVCV PRIVATE "src/HP4.cpp")
-    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_HP4=1")
+    target_compile_options(HP4
+        PUBLIC
+        "-fPIC"
+    )
+    target_compile_definitions(HP4
+        PUBLIC
+        "STONEYVCV_VERSION_MAJOR=${STONEYVCV_VERSION_MAJOR}"
+        "STONEYVCV_VERSION_MINOR=${STONEYVCV_VERSION_MINOR}"
+        "STONEYVCV_VERSION_PATCH=${STONEYVCV_VERSION_PATCH}"
+        "STONEYVCV_VERSION_TWEAK=${STONEYVCV_VERSION_TWEAK}"
+        "STONEYVCV_VERSION=${STONEYVCV_VERSION}"
+    )
+    target_link_libraries(HP4
+        PUBLIC
+        rack::lib
+        StoneyDSP::Core
+    )
+    target_link_libraries(plugin PUBLIC StoneyDSP::StoneyVCV::HP4)
+    target_compile_definitions(plugin PUBLIC "-DSTONEYVCV_BUILD_HP4=1")
+    list(APPEND STONEYVCV_TARGETS HP4)
 endif(STONEYVCV_BUILD_MODULE_HP4)
+
+if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+    if(STONEYVCV_BUILD_MODULE_HP4)
+        target_sources(tests
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP4.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP4)
+    if(STONEYVCV_BUILD_MODULE_HP2)
+        target_sources(tests
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP2.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP2)
+    if(STONEYVCV_BUILD_MODULE_HP1)
+        target_sources(tests
+        PRIVATE
+        "${PROJECT_SOURCE_DIR}/test/HP1.cpp"
+    )
+    endif(STONEYVCV_BUILD_MODULE_HP1)
+endif()
 
 endif(STONEYVCV_BUILD_MODULES)
 
@@ -272,59 +401,7 @@ endif(STONEYVCV_BUILD_MODULES)
 # USES_TERMINAL
 # )
 
-# # Only build tests if this project is the top-level project...
-#[==[Tests_StoneyVCV]==]
 if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
-
-    target_compile_definitions(StoneyVCV PUBLIC "-DSTONEYVCV_BUILD_TESTS=1")
-
-    find_package(Catch2 3.5.2 REQUIRED)
-
-    # # These tests can use the Catch2-provided main
-    add_executable(Tests_StoneyVCV)
-    add_executable(StoneyVCV::Tests_StoneyVCV ALIAS Tests_StoneyVCV)
-    add_executable(StoneyDSP::StoneyVCV::Tests_StoneyVCV ALIAS Tests_StoneyVCV)
-    target_include_directories(Tests_StoneyVCV
-        PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-    )
-    target_sources(Tests_StoneyVCV
-        PRIVATE
-        "${PROJECT_SOURCE_DIR}/test/plugin.cpp"
-    )
-    target_link_libraries(Tests_StoneyVCV
-        PRIVATE
-        rack::lib
-        StoneyDSP::StoneyVCV
-        Catch2::Catch2WithMain
-    )
-    set_target_properties(Tests_StoneyVCV
-        PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/test"
-        RUNTIME_OUTPUT_NAME "Tests_StoneyVCV"
-    )
-    target_compile_features(Tests_StoneyVCV PUBLIC cxx_std_17)
-    target_compile_features(Tests_StoneyVCV PUBLIC c_std_17)
-    if(STONEYVCV_BUILD_MODULE_HP4)
-        target_sources(Tests_StoneyVCV
-        PRIVATE
-        "${PROJECT_SOURCE_DIR}/test/HP4.cpp"
-    )
-    endif(STONEYVCV_BUILD_MODULE_HP4)
-    if(STONEYVCV_BUILD_MODULE_HP2)
-        target_sources(Tests_StoneyVCV
-        PRIVATE
-        "${PROJECT_SOURCE_DIR}/test/HP2.cpp"
-    )
-    endif(STONEYVCV_BUILD_MODULE_HP2)
-    if(STONEYVCV_BUILD_MODULE_HP1)
-        target_sources(Tests_StoneyVCV
-        PRIVATE
-        "${PROJECT_SOURCE_DIR}/test/HP1.cpp"
-    )
-    endif(STONEYVCV_BUILD_MODULE_HP1)
-
     enable_testing()
 
     include(CTest)
@@ -335,7 +412,30 @@ if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
     set(dl_paths)
     list(APPEND dl_paths "${rack_link_dir}")
 
-    catch_discover_tests(Tests_StoneyVCV)
-
-    list(APPEND STONEYVCV_TARGETS Tests_StoneyVCV)
+    catch_discover_tests(tests)
 endif()
+
+# install the target and create export-set
+install(TARGETS ${STONEYVCV_TARGETS}
+    EXPORT StoneyVCVTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILE_SET stoneyvcv_PLUGIN_PUBLIC_HEADERS DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/StoneyVCV"
+    FILE_SET stoneyvcv_HP1_PUBLIC_HEADERS DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/StoneyVCV"
+    FILE_SET stoneyvcv_HP2_PUBLIC_HEADERS DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/StoneyVCV"
+    FILE_SET stoneyvcv_HP4_PUBLIC_HEADERS DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/StoneyVCV"
+)
+
+# generate and install export file
+install(EXPORT StoneyVCVTargets
+    FILE "StoneyVCVTargets.cmake"
+    NAMESPACE StoneyDSP::StoneyVCV::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/StoneyVCV"
+)
+export(
+    TARGETS ${STONEYVCV_TARGETS}
+    FILE "share/cmake/StoneyVCVTargets.cmake"
+    NAMESPACE StoneyDSP::StoneyVCV::
+)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Created CMake Object Libraries for each Module, which the plugin then links with.

This has a really nice feature where the builds of individual modules can be parallelised, as well as made option-able and optional.

## What is the current behavior?

All modules files/code and the plugin file/code is all assigned to one single Shared Library target.

## What is the new behavior?

Each module is now an individual target in CMake, with additional trimmings like access to unique options, dependencies, and versioning, on a per-module basis.

Building three near-identical modules simultaneously has quickly showed me that I need some sort of functional approach for the creation of new Module targets, since the underlying CMake code is quite repetitive. [I've done that kinda thing before](https://github.com/nathanjhood/cmake-js/blob/master/share/cmake/CMakeJS.cmake) and looking forward to doing it some more, but as I learned previously it probably isn't as small a task as it may seem.