### PR TITLE
feat/cmake presets

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -15,11 +15,7 @@ env:
   DISPLAY: :0
   CMAKE_BUILD_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
-  VCPKG_DEFAULT_TRIPLET: "x64-osx"
-  VCPKG_DEFAULT_HOST_TRIPLET: "x64-osx"
-  VCPKG_OSX_ARCHITECTURES: "x86_64"
   VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-  VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/dep/vcpkg/ports
   BUILD_DIR: ${{ github.workspace }}/build
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SCCACHE_GHA_ENABLED: "true"
@@ -66,17 +62,7 @@ jobs:
     - name: Configure Tests
       run: >-
         cmake
-        -S ${{ github.workspace }}
-        -B ${{ env.BUILD_DIR }}
-        -DCMAKE_INSTALL_PREFIX:PATH=${{ github.workspace }}/install
-        -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
-        -DCMAKE_OSX_ARCHITECTURES:STRING="x86_64"
-        -DVCPKG_HOST_TRIPLET:STRING="x64-osx"
-        -DVCPKG_TARGET_TRIPLET:STRING="x64-osx"
-        -DSTONEYVCV_BUILD_TESTS:BOOL=TRUE
-        -G "Ninja"
-        --compile-no-warning-as-error
-        --no-warn-unused-cli
+        --preset x64-osx-release
         --fresh
 
     - name: Build Tests

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -84,8 +84,8 @@ jobs:
       run: >-
         cmake
         --install ${{ env.BUILD_DIR }}
-        --preset x64-osx-release
         --prefix ${{ github.workspace }}/install
+        --strip
         -j3
 
       # DEPLOYMENT WORKFLOW

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -98,20 +98,25 @@ jobs:
         unzip Rack-SDK-${{env.RACK_SDK_VERSION}}-${{env.RACK_SDK_PLATFORM}}.zip
         cd ..
 
+    - name: Dep
+      env:
+        RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
+      run: make dep -j 3
+
     - name: Build
       env:
         RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
-      run: make -j3
+      run: make -j 3
 
     - name: Dist
       env:
         RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
-      run: make dist -j3
+      run: make dist -j 3
 
     - name: Install
       env:
         RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
-      run: make install -j3
+      run: make install -j 3
 
     # List all files in tree
     - name: List

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -51,7 +51,7 @@ jobs:
       uses: johnwason/vcpkg-action@v6
       with:
         # vcpkg triplet to use
-        triplet: x64-osx
+        triplet: arm64-osx
         # GitHub token to authenticate API requests. Recommended to use  github.token
         token: ${{ github.token }}
         # Directory containing vcpkg.json manifest file. Cannot be used with pkgs.
@@ -63,14 +63,14 @@ jobs:
     - name: Configure Tests
       run: >-
         cmake
-        --preset x64-osx-release
+        --preset arm64-osx-release
         --fresh
 
     - name: Build Tests
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
-        --preset x64-osx-release
+        --preset arm64-osx-release
         --target tests
         -j 3
 
@@ -78,7 +78,7 @@ jobs:
       run: >-
         ctest
         --test-dir ${{ env.BUILD_DIR }}
-        --preset x64-osx-release
+        --preset arm64-osx-release
         -j 3
 
     - name: Install

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   DISPLAY: :0
   CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CMAKE_INSTALL_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
   VCPKG_ROOT: ${{ github.workspace }}/vcpkg
   BUILD_DIR: ${{ github.workspace }}/build
@@ -71,14 +72,14 @@ jobs:
         --build ${{ env.BUILD_DIR }}
         --preset x64-osx-release
         --target tests
-        -j3
+        -j 3
 
     - name: Test
       run: >-
         ctest
         --test-dir ${{ env.BUILD_DIR }}
         --preset x64-osx-release
-        -j3
+        -j 3
 
     - name: Install
       run: >-
@@ -86,7 +87,7 @@ jobs:
         --install ${{ env.BUILD_DIR }}
         --prefix ${{ github.workspace }}/install
         --strip
-        -j3
+        -j 3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -69,18 +69,24 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
+        --preset x64-osx-release
         --target tests
         -j3
 
     - name: Test
       run: >-
-        cd ${{ env.BUILD_DIR }} &&
         ctest
+        --test-dir ${{ env.BUILD_DIR }}
+        --preset x64-osx-release
         -j3
-        --rerun-failed
-        --output-on-failure
-        --verbose
-        && cd ${{ github.workspace }}
+
+    - name: Install
+      run: >-
+        cmake
+        --install ${{ env.BUILD_DIR }}
+        --preset x64-osx-release
+        --prefix ${{ github.workspace }}/install
+        -j3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -18,7 +18,6 @@ env:
   CMAKE_BUILD_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
   VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-  VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/dep/vcpkg/ports
   SCCACHE_GHA_ENABLED: "true"
   RACK_SDK_VERSION: 2.5.2
   RACK_SDK_PLATFORM: "lin-x64"
@@ -59,16 +58,7 @@ jobs:
     - name: Configure Tests
       run: >-
         cmake
-        -S ${{ github.workspace }}
-        -B ${{ env.BUILD_DIR }}
-        -DCMAKE_INSTALL_PREFIX:PATH=${{ github.workspace }}/install
-        -DCMAKE_TOOLCHAIN_FILE:FILEPATH="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
-        -DVCPKG_HOST_TRIPLET:STRING=x64-linux
-        -DVCPKG_TARGET_TRIPLET:STRING=x64-linux
-        -DSTONEYVCV_BUILD_TESTS:BOOL=TRUE
-        -G "Ninja"
-        --compile-no-warning-as-error
-        --no-warn-unused-cli
+        --preset x64-linux-release
         --fresh
 
     - name: Build Tests

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -94,6 +94,11 @@ jobs:
         unzip Rack-SDK-${{env.RACK_SDK_VERSION}}-${{env.RACK_SDK_PLATFORM}}.zip
         cd ..
 
+    - name: Dep
+      env:
+        RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
+      run: make dep -j 3
+
     - name: Build
       env:
         RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -16,6 +16,7 @@ env:
   BUILD_DIR: ${{ github.workspace }}/build
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CMAKE_INSTALL_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
   VCPKG_ROOT: ${{ github.workspace }}/vcpkg
   SCCACHE_GHA_ENABLED: "true"
@@ -67,14 +68,14 @@ jobs:
         --build ${{ env.BUILD_DIR }}
         --preset x64-linux-release
         --target tests
-        -j3
+        -j 3
 
     - name: Test
       run: >-
         ctest
         --test-dir ${{ env.BUILD_DIR }}
         --preset x64-linux-release
-        -j3
+        -j 3
 
     - name: Install
       run: >-
@@ -82,7 +83,7 @@ jobs:
         --install ${{ env.BUILD_DIR }}
         --prefix ${{ github.workspace }}/install
         --strip
-        -j3
+        -j 3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -65,18 +65,24 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
+        --preset x64-linux-release
         --target tests
         -j3
 
     - name: Test
       run: >-
-        cd ${{ env.BUILD_DIR }} &&
         ctest
+        --test-dir ${{ env.BUILD_DIR }}
+        --preset x64-linux-release
         -j3
-        --rerun-failed
-        --output-on-failure
-        --verbose
-        && cd ${{ github.workspace }}
+
+    - name: Install
+      run: >-
+        cmake
+        --install ${{ env.BUILD_DIR }}
+        --preset x64-linux-release
+        --prefix ${{ github.workspace }}/install
+        -j3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -80,8 +80,8 @@ jobs:
       run: >-
         cmake
         --install ${{ env.BUILD_DIR }}
-        --preset x64-linux-release
         --prefix ${{ github.workspace }}/install
+        --strip
         -j3
 
       # DEPLOYMENT WORKFLOW

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -138,6 +138,11 @@ jobs:
         unzip Rack-SDK-${{env.RACK_SDK_VERSION}}-${{env.RACK_SDK_PLATFORM}}.zip
         cd ..
 
+    - name: Dep
+      env:
+        RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
+      run: make dep -j 3
+
     - name: Build
       shell: msys2 {0}
       env:

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -123,8 +123,8 @@ jobs:
       run: >-
         cmake
         --install ${{ env.BUILD_DIR }}
-        --preset x64-windows-release
         --prefix ${PWD}/install
+        --strip
         -j3
 
       # DEPLOYMENT WORKFLOW

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -106,19 +106,26 @@ jobs:
       run: >-
         cmake
         --build ${{ env.BUILD_DIR }}
+        --preset x64-windows-release
         --target tests
         -j3
 
     - name: Test
       shell: msys2 {0}
       run: >-
-        cd build &&
         ctest
+        --test-dir ${{ env.BUILD_DIR }}
+        --preset x64-windows-release
         -j3
-        --rerun-failed
-        --output-on-failure
-        --verbose
-        && cd ..
+
+    - name: Install
+      shell: msys2 {0}
+      run: >-
+        cmake
+        --install ${{ env.BUILD_DIR }}
+        --preset x64-windows-release
+        --prefix ${PWD}/install
+        -j3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -15,11 +15,8 @@ env:
   DISPLAY: :0
   CMAKE_BUILD_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
-  VCPKG_DEFAULT_TRIPLET: "x64-mingw-dynamic"
-  VCPKG_DEFAULT_HOST_TRIPLET: "x64-mingw-dynamic"
   VCPKG_MANIFEST_MODE: ON
   VCPKG_ROOT: "vcpkg"
-  VCPKG_OVERLAY_PORTS: ${{ github.workspace }}\dep\vcpkg\ports
   BUILD_DIR: build
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SCCACHE_GHA_ENABLED: "true"
@@ -101,16 +98,7 @@ jobs:
       shell: msys2 {0}
       run: >-
         cmake
-        -S ${PWD}
-        -B ${PWD}/build
-        -DCMAKE_INSTALL_PREFIX=${PWD}/install
-        -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${PWD}/vcpkg/scripts/buildsystems/vcpkg.cmake
-        -DVCPKG_HOST_TRIPLET:STRING=x64-mingw-dynamic
-        -DVCPKG_TARGET_TRIPLET:STRING=x64-mingw-dynamic
-        -DSTONEYVCV_BUILD_TESTS:BOOL=TRUE
-        -G "Ninja"
-        --compile-no-warning-as-error
-        --no-warn-unused-cli
+        --preset x64-windows-release
         --fresh
 
     - name: Build Tests

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   DISPLAY: :0
   CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CMAKE_INSTALL_PARALLEL_LEVEL: 3
   VCPKG_MAX_CONCURRENCY: 3
   VCPKG_MANIFEST_MODE: ON
   VCPKG_ROOT: "vcpkg"
@@ -108,7 +109,7 @@ jobs:
         --build ${{ env.BUILD_DIR }}
         --preset x64-windows-release
         --target tests
-        -j3
+        -j 3
 
     - name: Test
       shell: msys2 {0}
@@ -116,7 +117,7 @@ jobs:
         ctest
         --test-dir ${{ env.BUILD_DIR }}
         --preset x64-windows-release
-        -j3
+        -j 3
 
     - name: Install
       shell: msys2 {0}
@@ -125,7 +126,7 @@ jobs:
         --install ${{ env.BUILD_DIR }}
         --prefix ${PWD}/install
         --strip
-        -j3
+        -j 3
 
       # DEPLOYMENT WORKFLOW
 

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -139,6 +139,7 @@ jobs:
         cd ..
 
     - name: Dep
+      shell: msys2 {0}
       env:
         RACK_DIR: ${{ github.workspace }}/dep/Rack-SDK
       run: make dep -j 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Artefact directories
 #
+/_CPack_Packages
 /vcpkg_installed
 /install
 /build
@@ -12,6 +13,13 @@
 /*.so
 /*.dylib
 /*.dll
+**.zip
+**.tar
+**.gz
+**.bz2
+**.sh
+**.tar.Z
+**.vcvplugin
 
 # Resource files
 #

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,28 +9,32 @@
     160
   ],
   "makefile.configureOnOpen": false,
+  "cmake.cmakePath": "cmake",
+  "cmake.ctestPath": "ctest",
+  "cmake.cpackPath": "cpack",
+  "cmake.languageSupport.enableFileAPI": true,
+  "cmake.cmakeCommunicationMode": "fileApi",
+  "cmake.sourceDirectory": "${workspaceFolder}",
+  "cmake.buildDirectory": "${workspaceFolder}/build",
+  "cmake.installPrefix": "${workspaceFolder}/install",
+  "cmake.exportCompileCommandsFile": true,
+  "cmake.loadCompileCommands": true,
+  "cmake.launchBehavior": "reuseTerminal",
+  "cmake.preferredGenerators": [
+    "Ninja",
+    "Ninja Multi-Config"
+  ],
   "cmake.configureOnOpen": true,
   "cmake.configureOnEdit": false,
-  "cmake.environment": {
-    "VCPKG_ROOT": "${env:VCPKG_ROOT}"
-  },
-  "cmake.configureArgs": [
-    "-DVCPKG_HOST_TRIPLET:STRING=x64-linux",
-    "-DVCPKG_TARGET_TRIPLET:STRING=x64-linux",
-    "-DCMAKE_TOOLCHAIN_FILE:STRING=${env:VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-    "-DSTONEYVCV_EXPERIMENTAL=ON",
-    "-DSTONEYVCV_BUILD_TESTS=ON",
-    "-DSTONEYVCV_BUILD_PLUGIN=ON",
-    "-DSTONEYVCV_BUILD_MODULES=ON",
-    "-DSTONEYVCV_BUILD_MODULE_HP4=ON",
-    "-DSTONEYVCV_BUILD_MODULE_HP2=ON",
-    "-DSTONEYVCV_BUILD_MODULE_HP1=ON",
-    "-DSTONEYVCV_BUILD_MODULE_VCA=ON",
-    "--no-warn-unused-cli",
-    "--compile-no-warning-as-error",
-    "-Wno-dev",
-    "--fresh"
-  ],
+  "cmake.clearOutputBeforeBuild": true,
+  "cmake.saveBeforeBuild": true,
+  "cmake.buildBeforeRun": true,
+
+  "cmake.deleteBuildDirOnCleanConfigure": false,
+  "cmake.useVsDeveloperEnvironment": "auto",
+  "cmake.automaticReconfigure": true,
+  "cmake.skipConfigureIfCachePresent": true,
+  "cmake.useCMakePresets": "always",
   "cmake.debugConfig": {
 		"cwd": "${workspaceFolder}",
 		"symbolSearchPath": "${workspaceFolder}/include",
@@ -47,10 +51,7 @@
 			"programOutput": true
 		}
 	},
-  "cmake.sourceDirectory": "${workspaceFolder}",
-  "cmake.buildDirectory": "${workspaceFolder}/build",
-  "cmake.installPrefix": "${workspaceFolder}/install",
-  "cmake.loadCompileCommands": true,
+
   "vcpkg.general.enable": false,
   "C_Cpp.autoAddFileAssociations": true,
   "C_Cpp.default.includePath": [
@@ -239,4 +240,5 @@
     "charconv": "cpp",
     "shared_mutex": "cpp"
   }
+
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
 
     find_package(Catch2 3.5.2 REQUIRED)
     add_executable(tests)
-    add_executable(StoneyVCV::test ALIAS tests)
-    add_executable(StoneyDSP::StoneyVCV::test ALIAS tests)
+    add_executable(StoneyVCV::tests ALIAS tests)
+    add_executable(StoneyDSP::StoneyVCV::tests ALIAS tests)
     target_include_directories(tests
         PUBLIC
         $<BUILD_INTERFACE:${STONEYVCV_BINARY_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,13 @@ set(STONEYVCV_VERSION_TWEAK "${CMAKE_PROJECT_VERSION_TWEAK}" CACHE STRING "" FOR
 set(STONEYVCV_VERSION "${CMAKE_PROJECT_VERSION}" CACHE STRING "" FORCE)
 
 option(STONEYVCV_EXPERIMENTAL                       "Use '-DSTONEYVCV_EXPERIMENTAL=ON|OFF' when configuring to toggle this option." OFF)
-option(STONEYVCV_BUILD_TESTS                        "Use '-DSTONEYVCV_BUILD_TESTS=ON|OFF' when configuring to toggle this option." OFF)
 option(STONEYVCV_BUILD_PLUGIN                       "Use '-DSTONEYVCV_BUILD_PLUGIN=ON|OFF' when configuring to toggle this option." ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULES      "Use '-DSTONEYVCV_BUILD_MODULES=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_PLUGIN" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP1   "Use '-DSTONEYVCV_BUILD_MODULE_HP1=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_MODULES" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP2   "Use '-DSTONEYVCV_BUILD_MODULE_HP2=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_MODULES" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP4   "Use '-DSTONEYVCV_BUILD_MODULE_HP4=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_MODULES" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_VCA   "Use '-DSTONEYVCV_BUILD_MODULE_VCA=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_EXPERIMENTAL" ON)
+cmake_dependent_option(STONEYVCV_BUILD_TESTS        "Use '-DSTONEYVCV_BUILD_TESTS=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_IS_TOP_LEVEL" ON)
 
 # Put components in the correct order of their dependencies on eachother to save tears...
 find_package(rack-sdk 2.5.2 REQUIRED COMPONENTS dep core lib CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ foreach(TARGET IN LISTS STONEYVCV_TARGETS)
     endif(STONEYVCV_EXPERIMENTAL)
 
     # Toggle unit test code
-            if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+    if(STONEYVCV_BUILD_TESTS)
                 target_sources(tests
                     PRIVATE
                 "${STONEYVCV_SOURCE_DIR}/test/StoneyVCV/${TARGET}.cpp"
@@ -206,7 +206,7 @@ foreach(TARGET IN LISTS STONEYVCV_TARGETS)
             PUBLIC
                 "-DSTONEYVCV_BUILD_TESTS=1"
                 )
-    endif(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+    endif(STONEYVCV_BUILD_TESTS)
 
     endforeach()
 
@@ -286,7 +286,7 @@ install(
 
 #[=============================[Enable Unit Tests]=============================]
 
-if(STONEYVCV_IS_TOP_LEVEL AND STONEYVCV_BUILD_TESTS)
+if(STONEYVCV_BUILD_TESTS)
     enable_testing()
     include(CTest)
     include(Catch)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -242,6 +242,51 @@
       }
     },
     {
+      "name": "arm64-osx",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "MacOS-only configuration",
+      "description": "This build is only available on MacOS",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "arm64-osx",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "arm64-osx",
+          "type": "STRING"
+        },
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64",
+        "VCPKG_DEFAULT_TRIPLET": "arm64-osx",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "arm64-osx"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "macOS",
+          "intelliSenseMode": "ios-clang-arm64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
       "name": "x64-linux-debug",
       "hidden": false,
       "inherits": [
@@ -342,6 +387,40 @@
         "release",
         "verbose"
       ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose"
+      ]
     }
   ],
   "buildPresets": [
@@ -408,6 +487,19 @@
       "name": "x64-osx",
       "hidden": true,
       "configurePreset": "x64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "arm64-osx",
+      "hidden": true,
+      "configurePreset": "arm64-osx",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -527,6 +619,44 @@
       "hidden": false,
       "inherits": [
         "x64-osx",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "configurePreset": "arm64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "configurePreset": "arm64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
         "release",
         "verbose"
       ]
@@ -617,6 +747,19 @@
       ]
     },
     {
+      "name": "arm64-osx",
+      "hidden": true,
+      "configurePreset": "arm64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
       "name": "x64-windows-debug",
       "hidden": false,
       "configurePreset": "x64-windows-debug",
@@ -729,6 +872,44 @@
         "release",
         "verbose"
       ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "hidden": false,
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "hidden": false,
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "hidden": false,
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose"
+      ]
     }
   ],
   "packagePresets": [
@@ -812,6 +993,19 @@
     {
       "name": "x64-osx",
       "configurePreset": "x64-osx",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "arm64-osx",
+      "configurePreset": "arm64-osx",
       "hidden": true,
       "inherits": [
         "base"
@@ -1045,6 +1239,82 @@
       "configurePreset": "x64-osx-release-verbose",
       "inherits": [
         "x64-osx",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-source",
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-source",
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-source-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-source-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
         "release",
         "source",
         "verbose"
@@ -1372,6 +1642,114 @@
         },
         {
           "name": "x64-osx-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "displayName": "MacOS Debug",
+      "description": "MacOS-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "arm64-osx-debug",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "displayName": "MacOS Release",
+      "description": "MacOS-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "arm64-osx-release",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "displayName": "MacOS Debug (verbose)",
+      "description": "MacOS-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "displayName": "MacOS Release (verbose)",
+      "description": "MacOS-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-release-source-verbose",
           "type": "package"
         }
       ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -197,9 +197,33 @@
       }
     },
     {
-      "name": "x64-osx",
+      "name": "osx",
       "hidden": true,
       "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
+        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64"
+      }
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "inherits": "osx",
       "displayName": "MacOS-only configuration",
       "description": "This build is only available on MacOS",
       "condition": {
@@ -215,18 +239,9 @@
         "VCPKG_TARGET_TRIPLET": {
           "value": "x64-osx",
           "type": "STRING"
-        },
-        "CMAKE_OSX_ARCHITECTURES": {
-          "value": "x86_64",
-          "type": "STRING"
-        },
-        "VCPKG_OSX_ARCHITECTURES": {
-          "value": "x86_64",
-          "type": "STRING"
         }
       },
       "environment": {
-        "VCPKG_OSX_ARCHITECTURES": "x86_64",
         "VCPKG_DEFAULT_TRIPLET": "x64-osx",
         "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-osx"
       },
@@ -260,18 +275,9 @@
         "VCPKG_TARGET_TRIPLET": {
           "value": "arm64-osx",
           "type": "STRING"
-        },
-        "CMAKE_OSX_ARCHITECTURES": {
-          "value": "x86_64;arm64",
-          "type": "STRING"
-        },
-        "VCPKG_OSX_ARCHITECTURES": {
-          "value": "x86_64;arm64",
-          "type": "STRING"
         }
       },
       "environment": {
-        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64",
         "VCPKG_DEFAULT_TRIPLET": "arm64-osx",
         "VCPKG_DEFAULT_TARGET_TRIPLET": "arm64-osx"
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,1380 @@
+{
+  "version": 9,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+
+  "configurePresets": [
+    {
+      "name": "base",
+      "description": "Base configuration for all presets",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "installDir": "${sourceDir}/install",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "hidden": true,
+      "warnings": {
+        "dev": false,
+        "unusedCli": false,
+        "uninitialized": false
+      },
+      "errors": {
+        "dev": false,
+        "deprecated": false
+      },
+      "environment": {
+        "VCPKG_ROOT": "$penv{VCPKG_ROOT}",
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/dep/vcpkg/ports",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/dep/vcpkg/triplets"
+      },
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+          "type": "PATH"
+        },
+        "CMAKE_CONFIGURATION_TYPES": {
+          "value": "Debug;Release",
+          "type": "STRING"
+        },
+        "STONEYVCV_EXPERIMENTAL": {
+          "value": "OFF",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_TESTS": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_PLUGIN": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULES": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULE_HP4": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULE_HP2": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULE_HP1": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULE_VCA": {
+          "value": "ON",
+          "type": "BOOL"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "value": "DEBUG",
+          "type": "STRING"
+        }
+      }
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "value": "RELEASE",
+          "type": "STRING"
+        }
+      }
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "systemVars": true,
+        "uninitialized": true,
+        "unusedCli": true
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": true
+      },
+      "environment": {
+        "VERBOSE": "1"
+      }
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-mingw-dynamic",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-mingw-dynamic",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "MSYSTEM": "MINGW64",
+        "VCPKG_DEFAULT_TRIPLET": "x64-mingw-dynamic",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-mingw-dynamic"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "Windows",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "Linux-only configuration",
+      "description": "This build is only available on Linux",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-linux",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-linux",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "VCPKG_DEFAULT_TRIPLET": "x64-linux",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "Linux",
+          "intelliSenseMode": "linux-gcc-x64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "MacOS-only configuration",
+      "description": "This build is only available on MacOS",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-osx",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-osx",
+          "type": "STRING"
+        },
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "VCPKG_OSX_ARCHITECTURES": "x86_64",
+        "VCPKG_DEFAULT_TRIPLET": "x64-osx",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-osx"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "macOS",
+          "intelliSenseMode": "ios-clang-x64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-linux-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "configurePreset": "base",
+      "description": "Base configuration for all presets"
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "configurePreset": "debug",
+      "configuration": "Debug",
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "configurePreset": "release",
+      "configuration": "Release",
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "verbose",
+      "configurePreset": "verbose",
+      "hidden": true,
+      "verbose": true,
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "configurePreset": "x64-windows",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "configurePreset": "x64-linux",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "configurePreset": "x64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "configurePreset": "x64-windows-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "configurePreset": "x64-windows-release",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "configurePreset": "x64-windows-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "configurePreset": "x64-windows-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "configurePreset": "x64-linux-release",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "configurePreset": "x64-linux-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "configurePreset": "x64-linux-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "configurePreset": "x64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "configurePreset": "x64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "configurePreset": "x64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "configurePreset": "x64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "configurePreset": "base",
+      "output": {
+        "outputOnFailure": true,
+        "labelSummary": true
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "configurePreset": "debug",
+      "configuration": "Debug",
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": true
+      }
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "configurePreset": "release",
+      "configuration": "Release",
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": false
+      }
+    },
+    {
+      "name": "verbose",
+      "configurePreset": "verbose",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "verbosity": "verbose"
+      }
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "configurePreset": "x64-windows",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "configurePreset": "x64-linux",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "configurePreset": "x64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "hidden": false,
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "hidden": false,
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "hidden": false,
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "hidden": false,
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-linux-debug-verbose",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-linux-release-verbose",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "hidden": false,
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "hidden": false,
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "packageVersion": "2.0.1",
+      "vendorName": "StoneyDSP",
+      "packageName": "StoneyVCV",
+      "configurePreset": "base"
+    },
+    {
+      "name": "source",
+      "hidden": true,
+      "configFile": "CPackSourceConfig.cmake"
+    },
+    {
+      "name": "build",
+      "hidden": true,
+      "configFile": "CPackConfig.cmake"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "configurations": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": true,
+        "verbose": true
+      }
+    },
+    {
+      "name": "x64-windows",
+      "configurePreset": "x64-windows",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "x64-linux",
+      "configurePreset": "x64-linux",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "x64-osx",
+      "configurePreset": "x64-osx",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "x64-windows-debug",
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-source",
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-windows-release-source",
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-source-verbose",
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-source-verbose",
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "configurePreset": "x64-linux-debug-verbose",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "configurePreset": "x64-linux-release-verbose",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-source",
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-linux-release-source",
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-source-verbose",
+      "configurePreset": "x64-linux-debug-verbose",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-source-verbose",
+      "configurePreset": "x64-linux-release-verbose",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-source",
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-osx-release-source",
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-source-verbose",
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-source-verbose",
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "source",
+        "verbose"
+      ]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "x64-windows-debug",
+      "displayName": "Windows Debug",
+      "description": "Windows-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-windows-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "displayName": "Windows Release",
+      "description": "Windows-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-windows-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "displayName": "Windows Debug (verbose)",
+      "description": "Windows-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "displayName": "Windows Release (verbose)",
+      "description": "Windows-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "displayName": "Linux Debug",
+      "description": "Linux-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-linux-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "test"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "displayName": "Linux Release",
+      "description": "Linux-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-linux-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "test"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "displayName": "Linux Debug (verbose)",
+      "description": "Linux-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "displayName": "Linux Release (verbose)",
+      "description": "Linux-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "displayName": "MacOS Debug",
+      "description": "MacOS-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-osx-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "displayName": "MacOS Release",
+      "description": "MacOS-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-osx-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "displayName": "MacOS Debug (verbose)",
+      "description": "MacOS-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "displayName": "MacOS Release (verbose)",
+      "description": "MacOS-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -160,3 +160,5 @@ package: test
 
 # Include the Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
+
+dep: reconfigure

--- a/Makefile
+++ b/Makefile
@@ -64,21 +64,29 @@ endif
 
 include $(RACK_DIR)/arch.mk
 
+ifdef ARCH_X64
+	TRIPLET_ARCH := x64
+endif
+
+ifdef ARCH_ARM64
+	TRIPLET_ARCH := arm64
+endif
+
 # Include deps
 ifdef ARCH_WIN
-	FLAGS += -I$(PWD)/build/vcpkg_installed/x64-mingw-dynamic/include
-	LDFLAGS += -L$(PWD)/build/vcpkg_installed/x64-mingw-dynamic/lib
+	TRIPLET_OS := mingw-dynamic
 endif
 
 ifdef ARCH_LIN
-	FLAGS += -I$(PWD)/build/vcpkg_installed/x64-linux/include
-	LDFLAGS += -L$(PWD)/build/vcpkg_installed/x64-linux/lib
+	TRIPLET_OS := linux
 endif
 
 ifdef ARCH_MAC
-	FLAGS += -I$(PWD)/build/vcpkg_installed/x64-osx/include
-	LDFLAGS += -L$(PWD)/build/vcpkg_installed/x64-osx/lib
+	TRIPLET_OS := osx
 endif
+
+FLAGS += -I$(PWD)/build/vcpkg_installed/$(TRIPLET_ARCH)-$(TRIPLET_OS)/include
+LDFLAGS += -L$(PWD)/build/vcpkg_installed/$(TRIPLET_ARCH)-$(TRIPLET_OS)/lib
 
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS += -I$(PWD)/include

--- a/README.md
+++ b/README.md
@@ -9,27 +9,55 @@ StoneyDSP modules for [VCV Rack 2](https://vcvrack.com/).
 
 ---
 
+## Quickstart
+
+```shell
+git clone https://github.com/StoneyDSP/StoneyVCV.git
+```
+
+```shell
+make dep
+```
+
+```shell
+make
+```
+
+```shell
+make install
+```
+
 ## Contents
 
 - [StoneyVCV](#stoneyvcv)
+  - [Quickstart](#quickstart)
   - [Requirements](#requirements)
   - [Build and Install StoneyVCV for VCV Rack 2 with Make](#build-and-install-stoneyvcv-for-vcv-rack-2-with-make)
   - [Develop, Test and Debug StoneyVCV for VCV Rack 2 with CMake and Catch2](#develop-test-and-deploy-stoneyvcv-for-vcv-rack-2-with-cmake-and-catch2)
+  - [Additional Functionality](#additional-functionality)
+    - [CMake Presets](#cmake-presets)
+    - [Makefile Commands](#makefile-commands)
   - [Further Reading](#further-reading)
 
 ---
 
 ## Requirements
 
-Complete the [Setting up your development environment](https://vcvrack.com/manual/Building#Setting-up-your-development-environment) section of the [VCV Rack Plugin Development guide](https://vcvrack.com/manual/Building).
+Complete the [Setting up your development environment](https://vcvrack.com/manual/Building#Setting-up-your-development-environment) section of the [VCV Rack Plugin Development guide](https://vcvrack.com/manual/Building). Briefly, you will need the following installations at minimum:
+
+- VCV Rack 2 Free
+- CMake
+- Ninja
+- GNU Make
+- A Bash-like command line
 
 StoneyVCV can be built in three ways:
 
-- Download [VCV Rack](https://vcvrack.com/Rack) and the Rack SDK ([Windows x64](https://vcvrack.com/downloads/Rack-SDK-latest-win-x64.zip) / [Mac x64+ARM64](https://vcvrack.com/downloads/Rack-SDK-latest-mac-x64+arm64.zip) / [Linux x64](https://vcvrack.com/downloads/Rack-SDK-latest-lin-x64.zip)), and build StoneyVCV from any location. (Easiest/fastest.)
+1. Download [VCV Rack](https://vcvrack.com/Rack) and the Rack SDK ([Windows x64](https://vcvrack.com/downloads/Rack-SDK-latest-win-x64.zip) / [Mac x64+ARM64](https://vcvrack.com/downloads/Rack-SDK-latest-mac-x64+arm64.zip) / [Linux x64](https://vcvrack.com/downloads/Rack-SDK-latest-lin-x64.zip)), and build StoneyVCV from any location. (Easiest/fastest.)
 
-- [Build Rack from source](https://vcvrack.com/manual/Building#Building-Rack) and build StoneyVCV in the `plugins/` folder. (Recommended for advanced developers.)
+2. [Build Rack from source](https://vcvrack.com/manual/Building#Building-Rack) and build StoneyVCV in the `plugins/` folder. (Recommended for advanced developers.)
 
-- Build for all architectures with one command using the [VCV Rack Plugin Toolchain](https://github.com/VCVRack/rack-plugin-toolchain). Native (Linux) or Docker (Linux, Mac, Windows). *Recommended 15 GB disk space, 8 GB RAM.*
+3. Build for all architectures with one command using the [VCV Rack Plugin Toolchain](https://github.com/VCVRack/rack-plugin-toolchain). Native (Linux) or Docker (Linux, Mac, Windows). *Recommended 15 GB disk space, 8 GB RAM.*
 
 ---
 
@@ -132,7 +160,88 @@ cd ..
 
 The unit tests executable should run in the terminal, and eventually indicate the success rate of all the tests combined.
 
+## Additional Functionality
+
+StoneyVCV packs some interesting features into its' design, including some well - thought-out and thoroughly tested build system features.
+
+All Modules, tests, and even the plugin itself are all optionable, by applying different configurations to the C++ compiler pre-processor (i.e., what CMake's 'configure' stage means). Module versioning, dependency injection, downstream deployment integration, and much more has been considered throughout the development cycle of StoneyVCV.
+
+To streamline much of these many options and configurations, we have provided some additional functionality which will brings a lot more control over the build (and deloyment, and debugging, and tests...) under smaller "macro"-like code signatures, with the use of tools such as CMake Presets and Makefile commands.
+
+These additional functions provide a wide coverage of the full feature set of StoneyVCV, usually in just a single command line argument each.
+
+### CMake Presets
+
+The following CMake Presets are available for easy access to various configurations:
+
+```txt
+x64-windows-debug
+x64-windows-release
+x64-windows-debug-verbose
+x64-windows-release-verbose
+```
+```txt
+x64-linux-debug
+x64-linux-release
+x64-linux-debug-verbose
+x64-linux-release-verbose
+```
+```txt
+x64-osx-debug
+x64-osx-release
+x64-osx-debug-verbose
+x64-osx-release-verbose
+```
+
+To use a CMake Preset, you can just pass the `--preset=` arg to CMake (no other args required):
+
+```shell
+cmake --preset x64-windows-release
+```
+
+*The above command will configure the plugin for Windows 64-bit in Release mode using the same settings that the Rack-SDK itself implements, respectively*
+
+### Makefile commands
+
+As a further helper, we have also organized our `Makefile` to *automatically detect* a relevant CMake Preset - if not manually chosen - and run CMake for us, using an *even simpler* command, which works on *all* platforms:
+
+```shell
+make configure
+```
+
+*The above command will configure the plugin for the host machine's platform; the CPU and OS are detected by the Rack-SDK itself, while the common environment variables `VERBOSE` and `DEBUG` may also be set or unset, to further adapt the behaviour of `make configure` according to your current environment.*
+
+Further CMake actions and workflows can be triggered via `make` in a similarly environment-sensitive manner:
+
+```shell
+make reconfigure
+```
+
+*Clears the current CMake cache file (not dir!) and runs the configure step again*
+
+```shell
+make build
+```
+
+*Builds all currently-enabled CMake targets*
+
+
+```shell
+make test
+```
+
+*Runs CTest on the build output directory, executing any tests it finds (i.e., Catch2 unit tests)*
+
+
+```shell
+make package
+```
+
+*Creates a local directory (`./install`) containing a distributable package, unarchived*
+
 The GitHub Workflows in our repository may be a useful reference, if any doubts.
+
+---
 
 Please feel welcome to submit pull requests of any changes you feel are useful, interesting, or appropriate, along with any technical notes and/or subjective reasoning; you may use [one of our PR templates](https://github.com/StoneyDSP/StoneyVCV/issues/new/choose) to help you get started - [all community contributions are gratefully recieved](https://github.com/StoneyDSP/StoneyVCV/blob/production/.github/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ x64-osx-debug-verbose
 x64-osx-release-verbose
 ```
 
+```txt
+arm64-osx-debug
+arm64-osx-release
+arm64-osx-debug-verbose
+arm64-osx-release-verbose
+```
+
 To use a CMake Preset, you can just pass the `--preset=` arg to CMake (no other args required):
 
 ```shell

--- a/dep.mk
+++ b/dep.mk
@@ -2,74 +2,31 @@ ifndef VCPKG_ROOT
 $(error VCPKG_ROOT is not defined)
 endif
 
-include $(RACK_DIR)/arch.mk
-
-ifdef ARCH_LIN
-	HOST_TRIPLET ?= x64-linux
-	TARGET_TRIPLET ?= x64-linux
-	XDG_DATA_HOME ?= $(HOME)/.local/share
-	RACK_USER_DIR ?= $(XDG_DATA_HOME)/Rack2
-endif
-
-ifdef ARCH_MAC
-	HOST_TRIPLET ?= x64-osx
-	TARGET_TRIPLET ?= x64-osx
-	RACK_USER_DIR ?= $(HOME)/Library/Application Support/Rack2
-	CODESIGN ?= codesign -f -s -
-endif
-
-ifdef ARCH_WIN
-	HOST_TRIPLET ?= x64-mingw-dynamic
-	TARGET_TRIPLET ?= x64-mingw-dynamic
-	RACK_USER_DIR ?= $(LOCALAPPDATA)/Rack2
-endif
-
-PLUGINS_DIR := $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)
-
-VCPKG ?= vcpkg
-
+GIT := git
+VCPKG := vcpkg
 CMAKE := cmake
 CTEST := ctest
 CPACK := cpack
 
-GENERATOR ?= "Ninja"
+# ifdef ARCH_LIN
+# 	XDG_DATA_HOME ?= $(HOME)/.local/share
+# 	RACK_USER_DIR ?= $(XDG_DATA_HOME)/Rack2
+# endif
 
-BUILD_TYPE ?= Release
+# ifdef ARCH_MAC
+# 	RACK_USER_DIR ?= $(HOME)/Library/Application Support/Rack2
+# 	CODESIGN ?= codesign -f -s -
+# endif
 
-SOURCE_DIR ?= $(PWD)
-BUILD_DIR ?= $(PWD)/build
+# ifdef ARCH_WIN
+# 	RACK_USER_DIR ?= $(LOCALAPPDATA)/Rack2
+# endif
 
-configure:
-	$(CMAKE) \
-	-S "$(PWD)" \
-	-B "$(BUILD_DIR)" \
-	-DSTONEYVCV_BUILD_TESTS:BOOL=TRUE \
-	-DSTONEYVCV_BUILD_MODULES:BOOL=TRUE \
-	-DSTONEYVCV_BUILD_HP1:BOOL=TRUE \
-	-DSTONEYVCV_BUILD_HP2:BOOL=TRUE \
-	-DSTONEYVCV_BUILD_HP4:BOOL=TRUE \
-	-DCMAKE_TOOLCHAIN_FILE:FILEPATH="$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake" \
-	-DCMAKE_INSTALL_PREFIX:PATH=$(PLUGINS_DIR) \
-	-DCMAKE_CONFIGURATION_TYPES_STRING="Debug;Release" \
-	-DCMAKE_BUILD_TYPE:STRING=$(BUILD_TYPE) \
-	-DVCPKG_HOST_TRIPLET:STRING=$(HOST_TRIPLET) \
-	-DVCPKG_TARGET_TRIPLET:STRING=$(TARGET_TRIPLET) \
-	-DVCPKG_OVERLAY_PORTS:FILEPATH=$(PWD)/dep/vcpkg/ports \
-	-G $(GENERATOR) \
-	--compile-no-warning-as-error \
-	--no-warn-unused-cli \
-	--fresh
+# PLUGINS_DIR := $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)
 
-tests: configure
-	$(CMAKE) \
-	--build $(BUILD_DIR) \
-	--target tests
+# GENERATOR ?= "Ninja"
 
+# BUILD_TYPE ?= Release
 
-test: tests
-	cd $(BUILD_DIR)
-	$(CTEST) \
-	--output-on-failure \
-	--rerun-failed \
-	--verbose
-	cd $(SOURCE_DIR)
+# SOURCE_DIR ?= $(PWD)
+# BUILD_DIR ?= $(PWD)/build

--- a/dep/VCVRack/Rack-SDK/.gitignore
+++ b/dep/VCVRack/Rack-SDK/.gitignore
@@ -1,3 +1,13 @@
+/_CPack_Packages
 /install
 /build
+/dist
 /out
+**.zip
+**.tar
+**.xz
+**.gz
+**.bz2
+**.sh
+**.tar.Z
+**.vcvplugin

--- a/dep/VCVRack/Rack-SDK/CMakeLists.txt
+++ b/dep/VCVRack/Rack-SDK/CMakeLists.txt
@@ -290,13 +290,10 @@ export(
 
 list(APPEND RACK_SDK_TARGETS core)
 
+## Intellisense helper...
 # add_library(rack-sdk INTERFACE)
 # add_library(unofficial-vcvrack::rack-sdk ALIAS rack-sdk)
-
-# file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/include/rack.hpp" [==[
-# // intellisense helper
-# #include "Rack-SDK/rack/rack.hpp"
-# ]==])
+# configure_file("include/rack.hpp" "include/rack.hpp")
 # target_sources(rack-sdk INTERFACE
 #     FILE_SET rack_sdk_INTERFACE_HEADERS
 #     TYPE HEADERS
@@ -309,7 +306,11 @@ list(APPEND RACK_SDK_TARGETS core)
 # )
 # target_compile_options(rack-sdk
 #     INTERFACE
-#     "-fPIC"
+#         "-fPIC"
+# )
+# target_link_libraries(rack-sdk
+#     INTERFACE
+#         unofficial-vcvrack::rack-sdk::core
 # )
 
 # # install the target and create export-set
@@ -696,5 +697,56 @@ install(
     DESTINATION
     "${CMAKE_INSTALL_LIBDIR}/cmake/Rack-SDK"
 )
+
+if(RACK_SDK_IS_TOP_LEVEL)
+    # add CPack to project
+    set(CPACK_PACKAGE_NAME "Rack-SDK")
+    set(CPACK_PACKAGE_VENDOR "VCV")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "CPack Component Installation Example")
+    set(CPACK_PACKAGE_VERSION "${RACK_SDK_VERSION_MAJOR}.${RACK_SDK_VERSION_MINOR}.${RACK_SDK_VERSION_PATCH}")
+    set(CPACK_PACKAGE_VERSION_MAJOR "${RACK_SDK_VERSION_MAJOR}")
+    set(CPACK_PACKAGE_VERSION_MINOR "${RACK_SDK_VERSION_MINOR}")
+    set(CPACK_PACKAGE_VERSION_PATCH "${RACK_SDK_VERSION_PATCH}")
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "Rack-SDK")
+    set(CPACK_SOURCE_IGNORE_FILES)
+    list(APPEND CPACK_SOURCE_IGNORE_FILES
+        "/_CPack_Packages/"
+        "/install/"
+        "/build/"
+        "/dist/"
+        "/out/"
+        "/.git/"
+        "/.github/"
+        "/.vscode/"
+        "/*.zip"
+        "/*.tar"
+        "/*.tar.gz"
+        "/*.tar.xz"
+        "/*.tar.bz2"
+        "/*.tar.Z"
+        "/*.sh"
+        "/*.vcvplugin"
+    )
+    # This must always be after all CPACK\_\* variables are defined
+    include(CPack)
+    cpack_add_component(dep
+        DISPLAY_NAME "Dependency C++ Headers"
+        DESCRIPTION "C/C++ header files for Rack-SDK's dependencies"
+        GROUP "Rack-SDK"
+    )
+    cpack_add_component(core
+        DISPLAY_NAME "C++ Headers"
+        DESCRIPTION "C/C++ header files for Rack-SDK"
+        GROUP "Rack-SDK"
+        DEPENDS dep
+    )
+    cpack_add_component(lib
+        DISPLAY_NAME "Shared Library"
+        DESCRIPTION "Dynamic library for Rack-SDK"
+        GROUP "Rack-SDK"
+        DEPENDS core
+    )
+    # cpack_add_component(rack-sdk)
+endif()
 
 unset(__RACK_SDK_HELPERS_FILE)

--- a/dep/VCVRack/Rack-SDK/CMakePresets.json
+++ b/dep/VCVRack/Rack-SDK/CMakePresets.json
@@ -1,0 +1,617 @@
+{
+  "version": 9,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+
+  "configurePresets": [
+    {
+      "name": "base",
+      "description": "Base configuration for all presets",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "installDir": "${sourceDir}/install",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "hidden": true,
+      "warnings": {
+        "dev": false,
+        "unusedCli": false,
+        "uninitialized": false
+      },
+      "errors": {
+        "dev": false,
+        "deprecated": false
+      },
+      "environment": {},
+      "cacheVariables": {
+        "CMAKE_CONFIGURATION_TYPES": {
+          "value": "Debug;Release",
+          "type": "STRING"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "value": "DEBUG",
+          "type": "STRING"
+        }
+      }
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "value": "RELEASE",
+          "type": "STRING"
+        }
+      }
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "warnings": {
+        "dev": true,
+        "deprecated": true,
+        "systemVars": true,
+        "uninitialized": true,
+        "unusedCli": true
+      },
+      "errors": {
+        "dev": true,
+        "deprecated": true
+      },
+      "environment": {
+        "VERBOSE": "1"
+      }
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-mingw-dynamic",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-mingw-dynamic",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "MSYSTEM": "MINGW64"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "Windows",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "Linux-only configuration",
+      "description": "This build is only available on Linux",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-linux",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-linux",
+          "type": "STRING"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "Linux",
+          "intelliSenseMode": "linux-gcc-x64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "MacOS-only configuration",
+      "description": "This build is only available on MacOS",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "x64-osx",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "x64-osx",
+          "type": "STRING"
+        },
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64",
+          "type": "STRING"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "macOS",
+          "intelliSenseMode": "ios-clang-x64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
+      "name": "x64-linux-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "description": "Base configuration for all presets"
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "configuration": "Debug",
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "configuration": "Release",
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "verbose": true,
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "configurePreset": "x64-windows-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "configurePreset": "x64-windows-release",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "configurePreset": "x64-windows-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "configurePreset": "x64-windows-release",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "configurePreset": "x64-linux-release",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "configurePreset": "x64-linux-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "configurePreset": "x64-linux-release",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "configurePreset": "x64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "configurePreset": "x64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "configurePreset": "x64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "configurePreset": "x64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "output": {
+        "outputOnFailure": true,
+        "labelSummary": true
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "configuration": "Debug",
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": true
+      }
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "configuration": "Release",
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": false
+      }
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "verbosity": "verbose"
+      }
+    },
+    {
+      "name": "x64-windows",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-linux",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "hidden": false,
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "hidden": false,
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "x64-linux-debug",
+      "displayName": "Linux Debug",
+      "description": "Linux-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-linux-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "test"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "displayName": "Linux Release",
+      "description": "Linux-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-linux-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "test"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "displayName": "Linux Debug (verbose)",
+      "description": "Linux-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-linux-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "test"
+        }
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "displayName": "Linux Release (verbose)",
+      "description": "Linux-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-linux-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "test"
+        }
+      ]
+    }
+  ]
+}

--- a/dep/VCVRack/Rack-SDK/CMakePresets.json
+++ b/dep/VCVRack/Rack-SDK/CMakePresets.json
@@ -224,6 +224,51 @@
       }
     },
     {
+      "name": "arm64-osx",
+      "hidden": true,
+      "inherits": "base",
+      "displayName": "MacOS-only configuration",
+      "description": "This build is only available on MacOS",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "VCPKG_HOST_TRIPLET": {
+          "value": "arm64-osx",
+          "type": "STRING"
+        },
+        "VCPKG_TARGET_TRIPLET": {
+          "value": "arm64-osx",
+          "type": "STRING"
+        },
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64",
+        "VCPKG_DEFAULT_TRIPLET": "arm64-osx",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "arm64-osx"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "autoFormat": true,
+          "hostOS": "macOS",
+          "intelliSenseMode": "ios-clang-arm64",
+          "intelliSenseOptions": {
+            "useCompilerDefaults": true
+          }
+        }
+      }
+    },
+    {
       "name": "x64-linux-debug",
       "hidden": false,
       "inherits": [
@@ -324,6 +369,40 @@
         "release",
         "verbose"
       ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose"
+      ]
     }
   ],
   "buildPresets": [
@@ -390,6 +469,19 @@
       "name": "x64-osx",
       "hidden": true,
       "configurePreset": "x64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "arm64-osx",
+      "hidden": true,
+      "configurePreset": "arm64-osx",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -509,6 +601,44 @@
       "hidden": false,
       "inherits": [
         "x64-osx",
+        "release",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "configurePreset": "arm64-osx-debug",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "configurePreset": "arm64-osx-release",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "arm64-osx",
         "release",
         "verbose"
       ]
@@ -599,6 +729,19 @@
       ]
     },
     {
+      "name": "arm64-osx",
+      "hidden": true,
+      "configurePreset": "arm64-osx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
       "name": "x64-windows-debug",
       "hidden": false,
       "configurePreset": "x64-windows-debug",
@@ -711,6 +854,44 @@
         "release",
         "verbose"
       ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "hidden": false,
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "hidden": false,
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "hidden": false,
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "hidden": false,
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose"
+      ]
     }
   ],
   "packagePresets": [
@@ -794,6 +975,19 @@
     {
       "name": "x64-osx",
       "configurePreset": "x64-osx",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "arm64-osx",
+      "configurePreset": "arm64-osx",
       "hidden": true,
       "inherits": [
         "base"
@@ -1027,6 +1221,82 @@
       "configurePreset": "x64-osx-release-verbose",
       "inherits": [
         "x64-osx",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-source",
+      "configurePreset": "arm64-osx-debug",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-source",
+      "configurePreset": "arm64-osx-release",
+      "inherits": [
+        "arm64-osx",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-source-verbose",
+      "configurePreset": "arm64-osx-debug-verbose",
+      "inherits": [
+        "arm64-osx",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "arm64-osx-release-source-verbose",
+      "configurePreset": "arm64-osx-release-verbose",
+      "inherits": [
+        "arm64-osx",
         "release",
         "source",
         "verbose"
@@ -1354,6 +1624,114 @@
         },
         {
           "name": "x64-osx-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-debug",
+      "displayName": "MacOS Debug",
+      "description": "MacOS-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "arm64-osx-debug",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-debug",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-release",
+      "displayName": "MacOS Release",
+      "description": "MacOS-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "arm64-osx-release",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-release",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-debug-verbose",
+      "displayName": "MacOS Debug (verbose)",
+      "description": "MacOS-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "arm64-osx-release-verbose",
+      "displayName": "MacOS Release (verbose)",
+      "description": "MacOS-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "arm64-osx-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "arm64-osx-release-source-verbose",
           "type": "package"
         }
       ]

--- a/dep/VCVRack/Rack-SDK/CMakePresets.json
+++ b/dep/VCVRack/Rack-SDK/CMakePresets.json
@@ -24,11 +24,33 @@
         "dev": false,
         "deprecated": false
       },
-      "environment": {},
+      "environment": {
+        "RACK_DIR": "$penv{RACK_DIR}",
+        "VCPKG_ROOT": "$penv{VCPKG_ROOT}"
+      },
       "cacheVariables": {
+        "RACK_DIR": {
+          "value": "$env{RACK_DIR}"
+        },
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+          "type": "PATH"
+        },
         "CMAKE_CONFIGURATION_TYPES": {
           "value": "Debug;Release",
           "type": "STRING"
+        },
+        "RACK_SDK_BUILD_DEPS": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "RACK_SDK_BUILD_CORE": {
+          "value": "ON",
+          "type": "BOOL"
+        },
+        "RACK_SDK_BUILD_LIB": {
+          "value": "ON",
+          "type": "BOOL"
         }
       },
       "vendor": {
@@ -106,7 +128,9 @@
         }
       },
       "environment": {
-        "MSYSTEM": "MINGW64"
+        "MSYSTEM": "MINGW64",
+        "VCPKG_DEFAULT_TRIPLET": "x64-mingw-dynamic",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-mingw-dynamic"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -138,6 +162,10 @@
           "value": "x64-linux",
           "type": "STRING"
         }
+      },
+      "environment": {
+        "VCPKG_DEFAULT_TRIPLET": "x64-linux",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-linux"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -179,6 +207,11 @@
           "type": "STRING"
         }
       },
+      "environment": {
+        "VCPKG_OSX_ARCHITECTURES": "x86_64",
+        "VCPKG_DEFAULT_TRIPLET": "x64-osx",
+        "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-osx"
+      },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "autoFormat": true,
@@ -207,6 +240,24 @@
       ]
     },
     {
+      "name": "x64-linux-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose"
+      ]
+    },
+    {
       "name": "x64-windows-debug",
       "hidden": false,
       "inherits": [
@@ -220,6 +271,24 @@
       "inherits": [
         "x64-windows",
         "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
       ]
     },
     {
@@ -237,17 +306,37 @@
         "x64-osx",
         "release"
       ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "hidden": false,
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
     }
   ],
   "buildPresets": [
     {
       "name": "base",
       "hidden": true,
+      "configurePreset": "base",
       "description": "Base configuration for all presets"
     },
     {
       "name": "debug",
       "hidden": true,
+      "configurePreset": "debug",
       "configuration": "Debug",
       "inherits": [
         "base"
@@ -256,6 +345,7 @@
     {
       "name": "release",
       "hidden": true,
+      "configurePreset": "release",
       "configuration": "Release",
       "inherits": [
         "base"
@@ -263,6 +353,7 @@
     },
     {
       "name": "verbose",
+      "configurePreset": "verbose",
       "hidden": true,
       "verbose": true,
       "inherits": [
@@ -272,6 +363,7 @@
     {
       "name": "x64-windows",
       "hidden": true,
+      "configurePreset": "x64-windows",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -284,6 +376,7 @@
     {
       "name": "x64-linux",
       "hidden": true,
+      "configurePreset": "x64-linux",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -296,6 +389,7 @@
     {
       "name": "x64-osx",
       "hidden": true,
+      "configurePreset": "x64-osx",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -325,7 +419,7 @@
     },
     {
       "name": "x64-windows-debug-verbose",
-      "configurePreset": "x64-windows-debug",
+      "configurePreset": "x64-windows-debug-verbose",
       "hidden": false,
       "inherits": [
         "x64-windows",
@@ -335,7 +429,7 @@
     },
     {
       "name": "x64-windows-release-verbose",
-      "configurePreset": "x64-windows-release",
+      "configurePreset": "x64-windows-release-verbose",
       "hidden": false,
       "inherits": [
         "x64-windows",
@@ -363,7 +457,7 @@
     },
     {
       "name": "x64-linux-debug-verbose",
-      "configurePreset": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug-verbose",
       "hidden": false,
       "inherits": [
         "x64-linux",
@@ -373,7 +467,7 @@
     },
     {
       "name": "x64-linux-release-verbose",
-      "configurePreset": "x64-linux-release",
+      "configurePreset": "x64-linux-release-verbose",
       "hidden": false,
       "inherits": [
         "x64-linux",
@@ -401,7 +495,7 @@
     },
     {
       "name": "x64-osx-debug-verbose",
-      "configurePreset": "x64-osx-debug",
+      "configurePreset": "x64-osx-debug-verbose",
       "hidden": false,
       "inherits": [
         "x64-osx",
@@ -411,7 +505,7 @@
     },
     {
       "name": "x64-osx-release-verbose",
-      "configurePreset": "x64-osx-release",
+      "configurePreset": "x64-osx-release-verbose",
       "hidden": false,
       "inherits": [
         "x64-osx",
@@ -424,6 +518,7 @@
     {
       "name": "base",
       "hidden": true,
+      "configurePreset": "base",
       "output": {
         "outputOnFailure": true,
         "labelSummary": true
@@ -432,6 +527,7 @@
     {
       "name": "debug",
       "hidden": true,
+      "configurePreset": "debug",
       "configuration": "Debug",
       "inherits": [
         "base"
@@ -443,6 +539,7 @@
     {
       "name": "release",
       "hidden": true,
+      "configurePreset": "release",
       "configuration": "Release",
       "inherits": [
         "base"
@@ -453,6 +550,7 @@
     },
     {
       "name": "verbose",
+      "configurePreset": "verbose",
       "hidden": true,
       "inherits": [
         "base"
@@ -464,6 +562,7 @@
     {
       "name": "x64-windows",
       "hidden": true,
+      "configurePreset": "x64-windows",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -476,6 +575,7 @@
     {
       "name": "x64-linux",
       "hidden": true,
+      "configurePreset": "x64-linux",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -488,6 +588,7 @@
     {
       "name": "x64-osx",
       "hidden": true,
+      "configurePreset": "x64-osx",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -495,6 +596,44 @@
       },
       "inherits": [
         "base"
+      ]
+    },
+    {
+      "name": "x64-windows-debug",
+      "hidden": false,
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "hidden": false,
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose"
       ]
     },
     {
@@ -518,7 +657,7 @@
     {
       "name": "x64-linux-debug-verbose",
       "hidden": false,
-      "configurePreset": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug-verbose",
       "inherits": [
         "x64-linux",
         "debug",
@@ -528,15 +667,481 @@
     {
       "name": "x64-linux-release-verbose",
       "hidden": false,
-      "configurePreset": "x64-linux-release",
+      "configurePreset": "x64-linux-release-verbose",
       "inherits": [
         "x64-linux",
         "release",
         "verbose"
       ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "hidden": false,
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "hidden": false,
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "hidden": false,
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "hidden": false,
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose"
+      ]
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "packageVersion": "2.0.1",
+      "vendorName": "StoneyDSP",
+      "packageName": "StoneyVCV",
+      "configurePreset": "base"
+    },
+    {
+      "name": "source",
+      "hidden": true,
+      "configFile": "CPackSourceConfig.cmake"
+    },
+    {
+      "name": "build",
+      "hidden": true,
+      "configFile": "CPackConfig.cmake"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "configurations": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "configurations": [
+        "Release"
+      ]
+    },
+    {
+      "name": "verbose",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "output": {
+        "debug": true,
+        "verbose": true
+      }
+    },
+    {
+      "name": "x64-windows",
+      "configurePreset": "x64-windows",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "x64-linux",
+      "configurePreset": "x64-linux",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "x64-osx",
+      "configurePreset": "x64-osx",
+      "hidden": true,
+      "inherits": [
+        "base"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "x64-windows-debug",
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-source",
+      "configurePreset": "x64-windows-debug",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-windows-release-source",
+      "configurePreset": "x64-windows-release",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-windows-debug-source-verbose",
+      "configurePreset": "x64-windows-debug-verbose",
+      "inherits": [
+        "x64-windows",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-windows-release-source-verbose",
+      "configurePreset": "x64-windows-release-verbose",
+      "inherits": [
+        "x64-windows",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-debug",
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-release",
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-verbose",
+      "configurePreset": "x64-linux-debug-verbose",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-release-verbose",
+      "configurePreset": "x64-linux-release-verbose",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-source",
+      "configurePreset": "x64-linux-debug",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-linux-release-source",
+      "configurePreset": "x64-linux-release",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-linux-debug-source-verbose",
+      "configurePreset": "x64-linux-debug-verbose",
+      "inherits": [
+        "x64-linux",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-linux-release-source-verbose",
+      "configurePreset": "x64-linux-release-verbose",
+      "inherits": [
+        "x64-linux",
+        "release",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "verbose",
+        "build"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-source",
+      "configurePreset": "x64-osx-debug",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-osx-release-source",
+      "configurePreset": "x64-osx-release",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "source"
+      ]
+    },
+    {
+      "name": "x64-osx-debug-source-verbose",
+      "configurePreset": "x64-osx-debug-verbose",
+      "inherits": [
+        "x64-osx",
+        "debug",
+        "source",
+        "verbose"
+      ]
+    },
+    {
+      "name": "x64-osx-release-source-verbose",
+      "configurePreset": "x64-osx-release-verbose",
+      "inherits": [
+        "x64-osx",
+        "release",
+        "source",
+        "verbose"
+      ]
     }
   ],
   "workflowPresets": [
+    {
+      "name": "x64-windows-debug",
+      "displayName": "Windows Debug",
+      "description": "Windows-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-windows-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-release",
+      "displayName": "Windows Release",
+      "description": "Windows-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-windows-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-debug-verbose",
+      "displayName": "Windows Debug (verbose)",
+      "description": "Windows-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-windows-release-verbose",
+      "displayName": "Windows Release (verbose)",
+      "description": "Windows-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-windows-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-windows-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
     {
       "name": "x64-linux-debug",
       "displayName": "Linux Debug",
@@ -553,6 +1158,14 @@
         {
           "name": "x64-linux-debug",
           "type": "test"
+        },
+        {
+          "name": "x64-linux-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-debug-source",
+          "type": "package"
         }
       ]
     },
@@ -572,6 +1185,14 @@
         {
           "name": "x64-linux-release",
           "type": "test"
+        },
+        {
+          "name": "x64-linux-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-release-source",
+          "type": "package"
         }
       ]
     },
@@ -581,7 +1202,7 @@
       "description": "Linux-only Debug workflow preset (verbose).",
       "steps": [
         {
-          "name": "x64-linux-debug",
+          "name": "x64-linux-debug-verbose",
           "type": "configure"
         },
         {
@@ -591,6 +1212,14 @@
         {
           "name": "x64-linux-debug-verbose",
           "type": "test"
+        },
+        {
+          "name": "x64-linux-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-debug-source-verbose",
+          "type": "package"
         }
       ]
     },
@@ -600,7 +1229,7 @@
       "description": "Linux-only Release workflow preset (verbose).",
       "steps": [
         {
-          "name": "x64-linux-release",
+          "name": "x64-linux-release-verbose",
           "type": "configure"
         },
         {
@@ -610,6 +1239,122 @@
         {
           "name": "x64-linux-release-verbose",
           "type": "test"
+        },
+        {
+          "name": "x64-linux-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-linux-release-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-debug",
+      "displayName": "MacOS Debug",
+      "description": "MacOS-only Debug workflow preset.",
+      "steps": [
+        {
+          "name": "x64-osx-debug",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-debug",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-debug-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-release",
+      "displayName": "MacOS Release",
+      "description": "MacOS-only Release workflow preset.",
+      "steps": [
+        {
+          "name": "x64-osx-release",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-release",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-release-source",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-debug-verbose",
+      "displayName": "MacOS Debug (verbose)",
+      "description": "MacOS-only Debug workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-debug-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-debug-source-verbose",
+          "type": "package"
+        }
+      ]
+    },
+    {
+      "name": "x64-osx-release-verbose",
+      "displayName": "MacOS Release (verbose)",
+      "description": "MacOS-only Release workflow preset (verbose).",
+      "steps": [
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "configure"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "build"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "test"
+        },
+        {
+          "name": "x64-osx-release-verbose",
+          "type": "package"
+        },
+        {
+          "name": "x64-osx-release-source-verbose",
+          "type": "package"
         }
       ]
     }

--- a/dep/VCVRack/Rack-SDK/CMakePresets.json
+++ b/dep/VCVRack/Rack-SDK/CMakePresets.json
@@ -179,9 +179,33 @@
       }
     },
     {
-      "name": "x64-osx",
+      "name": "osx",
       "hidden": true,
       "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        },
+        "VCPKG_OSX_ARCHITECTURES": {
+          "value": "x86_64;arm64",
+          "type": "STRING"
+        }
+      },
+      "environment": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
+        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64"
+      }
+    },
+    {
+      "name": "x64-osx",
+      "hidden": true,
+      "inherits": "osx",
       "displayName": "MacOS-only configuration",
       "description": "This build is only available on MacOS",
       "condition": {
@@ -197,18 +221,9 @@
         "VCPKG_TARGET_TRIPLET": {
           "value": "x64-osx",
           "type": "STRING"
-        },
-        "CMAKE_OSX_ARCHITECTURES": {
-          "value": "x86_64",
-          "type": "STRING"
-        },
-        "VCPKG_OSX_ARCHITECTURES": {
-          "value": "x86_64",
-          "type": "STRING"
         }
       },
       "environment": {
-        "VCPKG_OSX_ARCHITECTURES": "x86_64",
         "VCPKG_DEFAULT_TRIPLET": "x64-osx",
         "VCPKG_DEFAULT_TARGET_TRIPLET": "x64-osx"
       },
@@ -242,18 +257,9 @@
         "VCPKG_TARGET_TRIPLET": {
           "value": "arm64-osx",
           "type": "STRING"
-        },
-        "CMAKE_OSX_ARCHITECTURES": {
-          "value": "x86_64;arm64",
-          "type": "STRING"
-        },
-        "VCPKG_OSX_ARCHITECTURES": {
-          "value": "x86_64;arm64",
-          "type": "STRING"
         }
       },
       "environment": {
-        "VCPKG_OSX_ARCHITECTURES": "x86_64;arm64",
         "VCPKG_DEFAULT_TRIPLET": "arm64-osx",
         "VCPKG_DEFAULT_TARGET_TRIPLET": "arm64-osx"
       },

--- a/dep/VCVRack/Rack-SDK/include/rack.hpp
+++ b/dep/VCVRack/Rack-SDK/include/rack.hpp
@@ -1,0 +1,150 @@
+// #pragma once
+
+// #define RACK_SDK_RACK_HPP_INCLUDED 1
+
+// #include <Rack-SDK/rack/rack.hpp>
+
+#pragma once
+
+/*
+The following headers are the "public" API of Rack.
+
+Directly including Rack headers other than rack.hpp in your plugin is unsupported/unstable, since filenames and locations of symbols may change in any Rack version.
+*/
+
+#ifdef PRIVATE
+#warning "Plugins must only include rack.hpp. Including other Rack headers is unsupported."
+#endif
+
+/** Functions with the PRIVATE attribute should not be called by plugins.
+*/
+#ifdef __clang__
+#define PRIVATE __attribute__((deprecated("Using internal Rack function or symbol")))
+#else
+#define PRIVATE __attribute__((error("Using internal Rack function or symbol")))
+#endif
+
+
+#include <Rack-SDK/rack/common.hpp>
+#include <Rack-SDK/rack/math.hpp>
+#include <Rack-SDK/rack/string.hpp>
+#include <Rack-SDK/rack/system.hpp>
+#include <Rack-SDK/rack/mutex.hpp>
+#include <Rack-SDK/rack/random.hpp>
+#include <Rack-SDK/rack/network.hpp>
+#include <Rack-SDK/rack/asset.hpp>
+#include <Rack-SDK/rack/window/Window.hpp>
+#include <Rack-SDK/rack/context.hpp>
+#include <Rack-SDK/rack/audio.hpp>
+#include <Rack-SDK/rack/midi.hpp>
+#include <Rack-SDK/rack/settings.hpp>
+#include <Rack-SDK/rack/helpers.hpp>
+#include <Rack-SDK/rack/componentlibrary.hpp>
+
+#include <Rack-SDK/rack/widget/TransparentWidget.hpp>
+#include <Rack-SDK/rack/widget/OpenGlWidget.hpp>
+#include <Rack-SDK/rack/widget/OpaqueWidget.hpp>
+#include <Rack-SDK/rack/widget/FramebufferWidget.hpp>
+#include <Rack-SDK/rack/widget/TransformWidget.hpp>
+#include <Rack-SDK/rack/widget/event.hpp>
+#include <Rack-SDK/rack/widget/ZoomWidget.hpp>
+#include <Rack-SDK/rack/widget/SvgWidget.hpp>
+#include <Rack-SDK/rack/widget/Widget.hpp>
+
+#include <Rack-SDK/rack/ui/Tooltip.hpp>
+#include <Rack-SDK/rack/ui/MenuLabel.hpp>
+#include <Rack-SDK/rack/ui/MenuEntry.hpp>
+#include <Rack-SDK/rack/ui/List.hpp>
+#include <Rack-SDK/rack/ui/TooltipOverlay.hpp>
+#include <Rack-SDK/rack/ui/Slider.hpp>
+#include <Rack-SDK/rack/ui/Scrollbar.hpp>
+#include <Rack-SDK/rack/ui/ProgressBar.hpp>
+#include <Rack-SDK/rack/ui/MenuSeparator.hpp>
+#include <Rack-SDK/rack/ui/MenuOverlay.hpp>
+#include <Rack-SDK/rack/ui/Label.hpp>
+#include <Rack-SDK/rack/ui/TextField.hpp>
+#include <Rack-SDK/rack/ui/SequentialLayout.hpp>
+#include <Rack-SDK/rack/ui/MenuItem.hpp>
+#include <Rack-SDK/rack/ui/Button.hpp>
+#include <Rack-SDK/rack/ui/ChoiceButton.hpp>
+#include <Rack-SDK/rack/ui/OptionButton.hpp>
+#include <Rack-SDK/rack/ui/RadioButton.hpp>
+#include <Rack-SDK/rack/ui/Menu.hpp>
+#include <Rack-SDK/rack/ui/ScrollWidget.hpp>
+
+#include <Rack-SDK/rack/app/SliderKnob.hpp>
+#include <Rack-SDK/rack/app/MultiLightWidget.hpp>
+#include <Rack-SDK/rack/app/MidiDisplay.hpp>
+#include <Rack-SDK/rack/app/CircularShadow.hpp>
+#include <Rack-SDK/rack/app/AudioDisplay.hpp>
+#include <Rack-SDK/rack/app/LedDisplay.hpp>
+#include <Rack-SDK/rack/app/ModuleLightWidget.hpp>
+#include <Rack-SDK/rack/app/LightWidget.hpp>
+#include <Rack-SDK/rack/app/RailWidget.hpp>
+#include <Rack-SDK/rack/app/PortWidget.hpp>
+#include <Rack-SDK/rack/app/CableWidget.hpp>
+#include <Rack-SDK/rack/app/Switch.hpp>
+#include <Rack-SDK/rack/app/RackScrollWidget.hpp>
+#include <Rack-SDK/rack/app/Knob.hpp>
+#include <Rack-SDK/rack/app/Scene.hpp>
+#include <Rack-SDK/rack/app/RackWidget.hpp>
+#include <Rack-SDK/rack/app/ParamWidget.hpp>
+#include <Rack-SDK/rack/app/SvgKnob.hpp>
+#include <Rack-SDK/rack/app/SvgPanel.hpp>
+#include <Rack-SDK/rack/app/SvgPort.hpp>
+#include <Rack-SDK/rack/app/SvgSwitch.hpp>
+#include <Rack-SDK/rack/app/SvgScrew.hpp>
+#include <Rack-SDK/rack/app/ModuleWidget.hpp>
+#include <Rack-SDK/rack/app/SvgSlider.hpp>
+#include <Rack-SDK/rack/app/SvgButton.hpp>
+
+#include <Rack-SDK/rack/engine/Param.hpp>
+#include <Rack-SDK/rack/engine/ParamHandle.hpp>
+#include <Rack-SDK/rack/engine/LightInfo.hpp>
+#include <Rack-SDK/rack/engine/PortInfo.hpp>
+#include <Rack-SDK/rack/engine/Light.hpp>
+#include <Rack-SDK/rack/engine/Cable.hpp>
+#include <Rack-SDK/rack/engine/Port.hpp>
+#include <Rack-SDK/rack/engine/ParamQuantity.hpp>
+#include <Rack-SDK/rack/engine/Module.hpp>
+#include <Rack-SDK/rack/engine/Engine.hpp>
+
+#include <Rack-SDK/rack/plugin.hpp>
+#include <Rack-SDK/rack/plugin/callbacks.hpp>
+
+#include <Rack-SDK/rack/dsp/common.hpp>
+#include <Rack-SDK/rack/dsp/window.hpp>
+#include <Rack-SDK/rack/dsp/ode.hpp>
+#include <Rack-SDK/rack/dsp/minblep.hpp>
+#include <Rack-SDK/rack/dsp/fft.hpp>
+#include <Rack-SDK/rack/dsp/ringbuffer.hpp>
+#include <Rack-SDK/rack/dsp/resampler.hpp>
+#include <Rack-SDK/rack/dsp/fir.hpp>
+#include <Rack-SDK/rack/dsp/approx.hpp>
+#include <Rack-SDK/rack/dsp/midi.hpp>
+#include <Rack-SDK/rack/dsp/vumeter.hpp>
+#include <Rack-SDK/rack/dsp/filter.hpp>
+#include <Rack-SDK/rack/dsp/digital.hpp>
+#include <Rack-SDK/rack/dsp/convert.hpp>
+
+#include <Rack-SDK/rack/simd/Vector.hpp>
+#include <Rack-SDK/rack/simd/functions.hpp>
+
+
+namespace rack {
+
+
+// Import some namespaces for convenience
+using namespace logger;
+using namespace math;
+using namespace window;
+using namespace widget;
+using namespace ui;
+using namespace app;
+using plugin::Plugin;
+using plugin::Model;
+using namespace engine;
+using namespace componentlibrary;
+
+
+} // namespace rack

--- a/dep/VCVRack/Rack-SDK/plugin.schema.json
+++ b/dep/VCVRack/Rack-SDK/plugin.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/StoneyDSP/StoneyVCV/production/plugin.schema.json",
+  "type": "object",
+  "allOf": [
+    {
+      "required": [
+        "slug",
+        "name",
+        "version",
+        "license",
+        "author"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
+      "additionalProperties": false,
+      "properties": {
+        "slug": {
+          "description": "The unique identifier for your plugin. Case-sensitive. Slugs may only contain letters `a-z` and `A-Z`, numbers `0-9`, hyphens `-`, and underscores `_`. After your plugin is released, the slug must never change, otherwise patch compatibility would be broken. To guarantee uniqueness, it is a good idea to prefix the slug by your “brand name” if available, e.g. “MyCompany-MyPlugin”.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The human-readable name for your plugin. Used for labeling your plugin the VCV Library. Unlike slugs, the name can be changed at any time without breaking patch compatibility.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of your plugin should follow the form `MAJOR`.`MINOR`.`REVISION`. Do not include the “v” prefix—this is added automatically where appropriate. The `MAJOR` version should match the version of Rack your plugin is built for, e.g. `2`. You are free to choose the `MINOR`.`REVISION` part of your plugin version. For example, `MyPlugin 2.4.2` would specify that your plugin is compatible with Rack `2`.X. If you publish the source code in a git repository, it is recommended to add a git tag with `git tag vX.Y.Z` and `git push --tags`.",
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)*(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        },
+        "license": {
+          "description": "The license of your plugin. For open-source plugins, use the license identifier string from the SPDX License List, such as 'GPL-3.0-or-later', 'GPL-3.0-only', 'MIT', 'BSD-3-Clause', 'CC0-1.0', etc. For freeware plugins, use 'proprietary' (TODO: use 'https://vcvrack.com/freeware-eula' when available), or your own freeware license URL. For commercial plugins, use 'https://vcvrack.com/eula' if sold on the VCV Library, or your own commercial license URL.",
+          "type": "string"
+        },
+        "brand": {
+          "description": "Prefix string for all modules in your plugin. For example, the brand “VCV” is used by the Fundamental plugin to create 'VCV VCF', 'VCV Unity', etc. If blank or undefined, the plugin name is used.",
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "authorEmail": {
+          "type": "string"
+        },
+        "authorUrl": {
+          "type": "string"
+        },
+        "pluginUrl": {
+          "type": "string"
+        },
+        "manualUrl": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": "string"
+        },
+        "donateUrl": {
+          "type": "string"
+        },
+        "changelogUrl": {
+          "type": "string"
+        },
+        "modules": {
+          "type": "array"
+        },
+        "minRackVersion": {
+          "description": "Minimum version of Rack required to download the plugin from the VCV Library. VCV Rack 2.4.0+ is required to prevent downloading plugin packages with incompatible minRackVersion. Older Rack versions do not support this property and will download all plugin versions regardless of its value.",
+          "type": "string",
+          "pattern": "^\\d+(\\.\\d+)*(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        }
+      }
+    }
+  ]
+}

--- a/docs/BuildingTheTestsForCatch2WithCMake.md
+++ b/docs/BuildingTheTestsForCatch2WithCMake.md
@@ -11,7 +11,7 @@ Here is an example of how to build, and then run, the tests executable:
 ### 1. Configure tests with CMake
 
 ```shell
-cmake -S . -B ./build -G Ninja
+cmake -S . -B ./build -G Ninja -DSTONEYVCV_BUILD_TESTS=TRUE
 ```
 
 ### 2. Build tests with Ninja


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add CMake Presets for much better parity across users, platforms, and targets, with far less config.

## What is the current behavior?

Acquiring and configuring deps and/or tests is very platform-dependant and requires some amount of experience with CMake - a non-Rack-SDK-native dependency of our own.

## What is the new behavior?

All platform-dependant behaviour has been wrapped to provide 4 presets per platform, as follows:

```txt
x64-windows-debug
x64-windows-release
x64-windows-debug-verbose
x64-windows-release-verbose
x64-linux-debug
x64-linux-release
x64-linux-debug-verbose
x64-linux-release-verbose
x64-osx-debug
x64-osx-release
x64-osx-debug-verbose
x64-osx-release-verbose
arm64-osx-debug
arm64-osx-release
arm64-osx-debug-verbose
arm64-osx-release-verbose
```

CMake Presets can apply in several stages, of which I've created the completed set, which all follow the same naming convention outlined above. As of the current version of CMake and its' presets API, those are:

```txt
configure
build
test
package
workflow
```

About the `package` stage; there are four *additional* presets per platform in the package stage, as follows:

```txt
x64-windows-debug-source
x64-windows-release-source
x64-windows-debug-source-verbose
x64-windows-release-source-verbose
x64-linux-debug-source
x64-linux-release-source
x64-linux-debug-source-verbose
x64-linux-release-source-verbose
x64-osx-debug-source
x64-osx-release-source
x64-osx-debug-source-verbose
x64-osx-release-source-verbose
```

Those additional presets named above will run CPack on the *source* directory.

The respective presets without the `-source` specifier will run CPack on the *build* directory.

These additional presets are *only* available to the `package` stage; they *cannot* be specified as configure, build, test, or workflow presets. In fact, the workflow presets run these commands themselves.

About the `workflow` stage presets; these are, as the name suggests, a specified combination of various other stages, in some specified order. 

In our case, *all* workflows - which follow the preset naming convention specified at the beginning of this article - run the following steps in the following order:

```txt
configure
build (all targets)
test
pack (build)
pack (source)
```

Additionally,  the Makefile has been updated to call Rack-SDK's file which determines the platform architecture, and so forth; this information is then used to call a corresponding CMake Preset when running simple make commands, which are platform-independent:

```shell
make configure
```

```shell
make reconfigure
```

```shell
make build
```

```shell
make test
```

```shell
make package
```

```shell
make dep
```

## Additional context

See the CMakePresets.json file at project root.
