### PR TITLE
module/LFO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.14...3.31 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23...3.31 FATAL_ERROR)
 
 #[=================================[STONEYVCV]=================================]
 
 project(STONEYVCV
     VERSION 2.0.1.0
-    DESCRIPTION ""
-    HOMEPAGE_URL ""
+    DESCRIPTION "StoneyDSP Modules for VCV Rack 2."
+    HOMEPAGE_URL "https://github.com/StoneyDSP/StoneyVCV"
 )
 
 enable_language(C)
@@ -29,6 +29,7 @@ cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP1   "Use '-DSTONEYVCV_BUILD_MODU
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP2   "Use '-DSTONEYVCV_BUILD_MODULE_HP2=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_MODULES" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_HP4   "Use '-DSTONEYVCV_BUILD_MODULE_HP4=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_BUILD_MODULES" ON)
 cmake_dependent_option(STONEYVCV_BUILD_MODULE_VCA   "Use '-DSTONEYVCV_BUILD_MODULE_VCA=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_EXPERIMENTAL" ON)
+cmake_dependent_option(STONEYVCV_BUILD_MODULE_LFO   "Use '-DSTONEYVCV_BUILD_MODULE_LFO=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_EXPERIMENTAL" ON)
 cmake_dependent_option(STONEYVCV_BUILD_TESTS        "Use '-DSTONEYVCV_BUILD_TESTS=ON|OFF' when configuring to toggle this option." ON "STONEYVCV_IS_TOP_LEVEL" ON)
 
 # Put components in the correct order of their dependencies on eachother to save tears...
@@ -120,6 +121,7 @@ if(STONEYVCV_BUILD_MODULES)
     set(STONEYVCV_EXPERIMENTAL_MODULES)
     list(APPEND STONEYVCV_EXPERIMENTAL_MODULES # List of enabled experimental modules
         VCA
+        LFO
     )
 
     if(STONEYVCV_EXPERIMENTAL)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,7 +39,7 @@
           "type": "STRING"
         },
         "STONEYVCV_EXPERIMENTAL": {
-          "value": "ON",
+          "value": "OFF",
           "type": "BOOL"
         },
         "STONEYVCV_BUILD_TESTS": {
@@ -67,11 +67,11 @@
           "type": "BOOL"
         },
         "STONEYVCV_BUILD_MODULE_VCA": {
-          "value": "ON",
+          "value": "OFF",
           "type": "BOOL"
         },
         "STONEYVCV_BUILD_MODULE_LFO": {
-          "value": "ON",
+          "value": "OFF",
           "type": "BOOL"
         }
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,7 +39,7 @@
           "type": "STRING"
         },
         "STONEYVCV_EXPERIMENTAL": {
-          "value": "OFF",
+          "value": "ON",
           "type": "BOOL"
         },
         "STONEYVCV_BUILD_TESTS": {
@@ -69,6 +69,10 @@
         "STONEYVCV_BUILD_MODULE_VCA": {
           "value": "ON",
           "type": "BOOL"
+        },
+        "STONEYVCV_BUILD_MODULE_LFO": {
+          "value": "ON",
+          "type": "BOOL"
         }
       },
       "vendor": {
@@ -88,7 +92,7 @@
       ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": {
-          "value": "DEBUG",
+          "value": "Debug",
           "type": "STRING"
         }
       }
@@ -101,7 +105,7 @@
       ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": {
-          "value": "RELEASE",
+          "value": "Release",
           "type": "STRING"
         }
       }

--- a/include/StoneyVCV/LFO.hpp
+++ b/include/StoneyVCV/LFO.hpp
@@ -168,8 +168,8 @@ public:
     LFOModuleWidget(::StoneyDSP::StoneyVCV::LFO::LFOModule* module);
     ~LFOModuleWidget();
 private:
-    // ::StoneyDSP::StoneyVCV::LFO::LFOWidget *lfoWidget;
-    // ::rack::FramebufferWidget *lfoModuleWidgetFrameBuffer;
+    ::StoneyDSP::StoneyVCV::LFO::LFOWidget *lfoWidget;
+    ::rack::FramebufferWidget *lfoModuleWidgetFrameBuffer;
     STONEYDSP_DECLARE_NON_COPYABLE(LFOModuleWidget)
     STONEYDSP_DECLARE_NON_MOVEABLE(LFOModuleWidget)
 };

--- a/include/StoneyVCV/LFO.hpp
+++ b/include/StoneyVCV/LFO.hpp
@@ -1,0 +1,201 @@
+/***************************************************************************//**
+ * @file LFO.hpp
+ * @author Nathan J. Hood <nathanjhood@googlemail.com>
+ * @brief
+ * @version 0.0.0
+ * @date 2024-11-11
+ *
+ * @copyright Copyright (c) 2024
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * therights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/orsell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#define STONEYVCV_LFO_HPP_INCLUDED 1
+
+//==============================================================================
+
+#include <rack.hpp>
+#include <StoneyDSP/Core.hpp>
+#include <StoneyDSP/DSP.hpp>
+#include <StoneyDSP/SIMD.hpp>
+
+//==============================================================================
+
+#include "plugin.hpp"
+
+//==============================================================================
+
+namespace StoneyDSP
+{
+/** @addtogroup StoneyDSP
+ *  @{
+ */
+
+//==============================================================================
+
+namespace StoneyVCV
+{
+/** @addtogroup StoneyVCV
+ *  @{
+ */
+
+//==============================================================================
+
+namespace LFO
+{
+/** @addtogroup LFO
+ *  @{
+ */
+
+//==============================================================================
+
+/**
+ * @brief The `LFOModule` class.
+ *
+ */
+struct LFOModule final :
+    ::rack::engine::Module
+{
+public:
+
+    using ProcessArgs = ::rack::engine::Module::ProcessArgs;
+
+    enum ParamsId {
+        PARAMS_LEN
+    };
+	enum InputsId {
+		INPUTS_LEN
+	};
+	enum OutputsId {
+		OUTPUTS_LEN
+	};
+	enum LightsId {
+		LIGHTS_LEN
+	};
+
+    /**
+     * @brief Construct a new `LFOModule` object.
+     *
+     */
+    LFOModule();
+
+    /**
+     * @brief Destroy the `LFOModule` object.
+     *
+     */
+    ~LFOModule();
+
+    /**
+     * @brief Advances the module by one audio sample.
+     *
+     * @param args
+     */
+    virtual void process(const ::StoneyDSP::StoneyVCV::LFO::LFOModule::ProcessArgs &args) override;
+
+    ::json_t *dataToJson() override;
+
+    void dataFromJson(::json_t *rootJ) override;
+
+private:
+    STONEYDSP_DECLARE_NON_COPYABLE(LFOModule)
+    STONEYDSP_DECLARE_NON_MOVEABLE(LFOModule)
+};
+
+//==============================================================================
+
+/**
+ * @brief The `LFOWidget` class.
+ *
+ */
+struct LFOWidget final :
+    ::rack::Widget
+{
+public:
+    LFOWidget();
+    ~LFOWidget();
+    /**
+     * @brief Advances the module by one frame.
+     *
+     */
+    void step() override;
+    /**
+     * @brief Draws the widget to the NanoVG context.
+     * When overriding, call the superclass's draw(args) to recurse to
+     * children.
+     *
+     * @param args
+     */
+    void draw(const ::rack::Widget::DrawArgs &args) override;
+    ::rack::FramebufferWidget *lfoWidgetFrameBuffer;
+    ::rack::Widget *panelBorder;
+private:
+    STONEYDSP_DECLARE_NON_COPYABLE(LFOWidget)
+    STONEYDSP_DECLARE_NON_MOVEABLE(LFOWidget)
+};
+
+//==============================================================================
+
+/**
+ * @brief The `LFOModuleWidget` struct.
+ *
+ * @tparam T
+ */
+struct LFOModuleWidget final :
+    ::rack::app::ModuleWidget
+{
+public:
+    LFOModuleWidget(::StoneyDSP::StoneyVCV::LFO::LFOModule* module);
+    ~LFOModuleWidget();
+private:
+    // ::StoneyDSP::StoneyVCV::LFO::LFOWidget *lfoWidget;
+    // ::rack::FramebufferWidget *lfoModuleWidgetFrameBuffer;
+    STONEYDSP_DECLARE_NON_COPYABLE(LFOModuleWidget)
+    STONEYDSP_DECLARE_NON_MOVEABLE(LFOModuleWidget)
+};
+
+//==============================================================================
+
+/**
+ * @brief
+ *
+ * @return `rack::plugin::Model*`
+ */
+::rack::plugin::Model *createLFO(); // STONEYDSP_NOEXCEPT(false);
+
+//==============================================================================
+
+  /// @} group LFO
+} // namespace LFO
+
+//==============================================================================
+
+  /// @} group StoneyVCV
+} // namespace StoneyVCV
+
+//==============================================================================
+
+  /// @} group StoneyDSP
+} // namespace StoneyDSP
+
+//==============================================================================

--- a/include/StoneyVCV/plugin.hpp
+++ b/include/StoneyVCV/plugin.hpp
@@ -62,6 +62,9 @@ extern ::rack::plugin::Plugin* pluginInstance;
     namespace VCA {
         extern ::rack::plugin::Model* modelVCA;
     }
+    namespace LFO {
+        extern ::rack::plugin::Model* modelLFO;
+    }
 #endif
 
 #if (STONEYVCV_VERSION_MAJOR >= 0) && (STONEYVCV_VERSION_MINOR >= 0) && (STONEYVCV_VERSION_PATCH >= 1)

--- a/src/StoneyVCV/LFO.cpp
+++ b/src/StoneyVCV/LFO.cpp
@@ -107,7 +107,7 @@ void ::StoneyDSP::StoneyVCV::LFO::LFOWidget::draw(const ::rack::Widget::DrawArgs
 
 ::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget::LFOModuleWidget(::StoneyDSP::StoneyVCV::LFO::LFOModule* module) {
     setModule(module);
-    setPanel(::rack::createPanel<::rack::app::SvgPanel>(
+    setPanel(::rack::createPanel<::rack::app::ThemedSvgPanel>(
         ::rack::asset::plugin(::StoneyDSP::StoneyVCV::pluginInstance, "res/LFO-light.svg"),
         ::rack::asset::plugin(::StoneyDSP::StoneyVCV::pluginInstance, "res/LFO-dark.svg")
     ));

--- a/src/StoneyVCV/LFO.cpp
+++ b/src/StoneyVCV/LFO.cpp
@@ -1,0 +1,189 @@
+/***************************************************************************//**
+ * @file LFO.cpp
+ * @author Nathan J. Hood <nathanjhood@googlemail.com>
+ * @brief
+ * @version 0.0.0
+ * @date 2024-11-11
+ *
+ * @copyright Copyright (c) 2024
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * therights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/orsell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ******************************************************************************/
+
+//==============================================================================
+
+#include <rack.hpp>
+
+//==============================================================================
+
+#include "StoneyVCV/LFO.hpp"
+
+//==============================================================================
+
+::StoneyDSP::StoneyVCV::LFO::LFOModule::LFOModule()
+{
+    // Configure the number of Params, Outputs, Inputs, and Lights.
+    config(
+        ::StoneyDSP::StoneyVCV::LFO::LFOModule::PARAMS_LEN,     // numParams
+        ::StoneyDSP::StoneyVCV::LFO::LFOModule::INPUTS_LEN,     // numInputs
+        ::StoneyDSP::StoneyVCV::LFO::LFOModule::OUTPUTS_LEN,    // numOutputs
+        ::StoneyDSP::StoneyVCV::LFO::LFOModule::LIGHTS_LEN      // numLights
+    );
+}
+
+::StoneyDSP::StoneyVCV::LFO::LFOModule::~LFOModule()
+{
+
+}
+
+void ::StoneyDSP::StoneyVCV::LFO::LFOModule::process(const ::StoneyDSP::StoneyVCV::LFO::LFOModule::ProcessArgs &args)
+{
+    ::StoneyDSP::ignoreUnused(args);
+}
+
+::json_t *::StoneyDSP::StoneyVCV::LFO::LFOModule::dataToJson()
+{
+    ::json_t *rootJ = ::json_object();
+    return rootJ;
+}
+
+void ::StoneyDSP::StoneyVCV::LFO::LFOModule::dataFromJson(::json_t *rootJ)
+{
+    ::StoneyDSP::ignoreUnused(rootJ);
+}
+
+//==============================================================================
+
+::StoneyDSP::StoneyVCV::LFO::LFOWidget::LFOWidget()
+{
+    // Widgets
+    lfoWidgetFrameBuffer = new ::rack::FramebufferWidget;
+    lfoWidgetFrameBuffer->setSize(box.size);
+    addChild(lfoWidgetFrameBuffer);
+}
+
+::StoneyDSP::StoneyVCV::LFO::LFOWidget::~LFOWidget()
+{
+
+}
+
+//==============================================================================
+
+::StoneyDSP::StoneyVCV::LFO::LFOWidget::LFOWidget()
+{
+    // Widgets
+    lfoWidgetFrameBuffer = new ::rack::FramebufferWidget;
+    lfoWidgetFrameBuffer->setSize(box.size);
+    addChild(lfoWidgetFrameBuffer);
+}
+
+::StoneyDSP::StoneyVCV::LFO::LFOWidget::~LFOWidget()
+{
+    // delete lfoWidgetFrameBuffer;
+}
+
+void ::StoneyDSP::StoneyVCV::LFO::LFOWidget::step()
+{
+    panelBorder->box.size = box.size;
+    ::rack::Widget::step();
+}
+
+void ::StoneyDSP::StoneyVCV::LFO::LFOWidget::draw(const ::rack::Widget::DrawArgs &args)
+{
+
+    ::nvgBeginPath(args.vg);
+    ::nvgRect(args.vg, 0.0, 0.0, box.size.x, box.size.y);
+    ::NVGcolor bg = ::rack::settings::preferDarkPanels ? ::nvgRGB(42, 42, 42) : ::nvgRGB(235, 235, 235);
+    ::nvgFillColor(args.vg, bg);
+    ::nvgFill(args.vg);
+    ::rack::Widget::draw(args);
+}
+
+//==============================================================================
+
+::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget::LFOModuleWidget(::StoneyDSP::StoneyVCV::LFO::LFOModule* module) {
+    setModule(module);
+    setPanel(::rack::createPanel<::rack::app::SvgPanel>(
+        ::rack::asset::plugin(::StoneyDSP::StoneyVCV::pluginInstance, "res/LFO-light.svg"),
+        ::rack::asset::plugin(::StoneyDSP::StoneyVCV::pluginInstance, "res/LFO-dark.svg")
+    ));
+    // Widgets
+    lfoModuleWidgetFrameBuffer = new ::rack::FramebufferWidget;
+    lfoModuleWidgetFrameBuffer->setSize(box.size);
+    addChild(lfoModuleWidgetFrameBuffer);
+    //
+    lfoWidget = ::rack::createWidget<::StoneyDSP::StoneyVCV::LFO::LFOWidget>(::rack::math::Vec(0.0f, 0.0f));
+    lfoWidget->setSize(box.size);
+    lfoModuleWidgetFrameBuffer->addChild(lfoWidget);
+    // Scews
+    addChild(::rack::createWidget<::rack::componentlibrary::ScrewSilver>(::rack::math::Vec(::rack::RACK_GRID_WIDTH, 0.0f)));
+    addChild(::rack::createWidget<::rack::componentlibrary::ScrewSilver>(::rack::math::Vec(box.size.x - 2.0f * ::rack::RACK_GRID_WIDTH, 0.0f)));
+    addChild(::rack::createWidget<::rack::componentlibrary::ScrewSilver>(::rack::math::Vec(::rack::RACK_GRID_WIDTH, ::rack::RACK_GRID_HEIGHT - ::rack::RACK_GRID_WIDTH)));
+    addChild(::rack::createWidget<::rack::componentlibrary::ScrewSilver>(::rack::math::Vec(box.size.x - 2.0f * ::rack::RACK_GRID_WIDTH, ::rack::RACK_GRID_HEIGHT - ::rack::RACK_GRID_WIDTH)));
+}
+
+::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget::~LFOModuleWidget()
+{
+    // delete lfoModuleWidgetFrameBuffer;
+}
+
+//==============================================================================
+
+::rack::plugin::Model* ::StoneyDSP::StoneyVCV::LFO::createLFO() // STONEYDSP_NOEXCEPT(false)
+{
+    ::rack::plugin::Model* modelLFO = ::rack::createModel<
+        ::StoneyDSP::StoneyVCV::LFO::LFOModule,
+        ::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget
+    >("LFO");
+    // STONEYDSP_THROW_IF_FAILED_VOID(modelVCO == nullptr, bad_alloc);
+    return modelLFO;
+}
+
+//==============================================================================
+
+namespace StoneyDSP {
+
+//==============================================================================
+
+namespace StoneyVCV {
+
+//==============================================================================
+
+namespace LFO {
+
+//==============================================================================
+
+::rack::plugin::Model* modelLFO = ::StoneyDSP::StoneyVCV::LFO::createLFO();
+
+//==============================================================================
+
+} // namespace LFO
+
+//==============================================================================
+
+} // namespace StoneyVCV
+
+//==============================================================================
+
+} // namespace StoneyDSP
+
+//==============================================================================

--- a/src/StoneyVCV/LFO.cpp
+++ b/src/StoneyVCV/LFO.cpp
@@ -83,21 +83,6 @@ void ::StoneyDSP::StoneyVCV::LFO::LFOModule::dataFromJson(::json_t *rootJ)
 
 ::StoneyDSP::StoneyVCV::LFO::LFOWidget::~LFOWidget()
 {
-
-}
-
-//==============================================================================
-
-::StoneyDSP::StoneyVCV::LFO::LFOWidget::LFOWidget()
-{
-    // Widgets
-    lfoWidgetFrameBuffer = new ::rack::FramebufferWidget;
-    lfoWidgetFrameBuffer->setSize(box.size);
-    addChild(lfoWidgetFrameBuffer);
-}
-
-::StoneyDSP::StoneyVCV::LFO::LFOWidget::~LFOWidget()
-{
     // delete lfoWidgetFrameBuffer;
 }
 

--- a/src/StoneyVCV/plugin.cpp
+++ b/src/StoneyVCV/plugin.cpp
@@ -56,6 +56,7 @@ void init(::rack::plugin::Plugin* p) {
 #ifdef STONEYVCV_EXPERIMENTAL
     // EXPERIMENTAL MODULES HERE...
     p->addModel(::StoneyDSP::StoneyVCV::VCA::modelVCA);
+    p->addModel(::StoneyDSP::StoneyVCV::LFO::modelLFO);
 #endif
 
 #if (STONEYVCV_VERSION_MAJOR >= 0) && (STONEYVCV_VERSION_MINOR >= 0) && (STONEYVCV_VERSION_PATCH >= 1)

--- a/test/StoneyVCV/LFO.cpp
+++ b/test/StoneyVCV/LFO.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file LFO.cpp
+ * @author Nathan J. Hood <nathanjhood@googlemail.com>
+ * @brief
+ * @version 0.0.0
+ * @date 2024-11-11
+ *
+ * @copyright Copyright (c) 2024
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * therights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/orsell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ******************************************************************************/
+
+//==============================================================================
+
+#if (STONEYVCV_BUILD_LFO == 1) && (STONEYVCV_BUILD_TESTS == 1)
+
+//==============================================================================
+
+#include <catch2/catch_test_macros.hpp>
+// for floating point comparisons
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+//==============================================================================
+
+#include "StoneyVCV/plugin.hpp"
+#include "StoneyVCV/LFO.hpp"
+
+//==============================================================================
+
+// Spec goes here...
+
+namespace StoneyDSP {
+namespace StoneyVCV {
+namespace LFO {
+struct LFOSpec final : ::StoneyDSP::StoneyVCV::Spec
+{
+public:
+    std::string slug;
+    static constexpr int NUM_PARAMS = 0;
+    static constexpr int NUM_INPUTS = 0;
+    static constexpr int NUM_OUTPUTS = 0;
+    static constexpr int NUM_LIGHTS = 0;
+    LFOSpec() : slug("LFO") {};
+private:
+    // STONEYDSP_DECLARE_NON_CONSTRUCTABLE(LFOSpec)
+    STONEYDSP_DECLARE_NON_COPYABLE(LFOSpec)
+    STONEYDSP_DECLARE_NON_MOVEABLE(LFOSpec)
+};
+}
+}
+}
+
+//==============================================================================
+
+// Tests go here...
+
+TEST_CASE( "LFO", "[LFO]" ) {
+
+    std::shared_ptr<::StoneyDSP::StoneyVCV::LFO::LFOSpec> spec = std::make_shared<::StoneyDSP::StoneyVCV::LFO::LFOSpec>();
+
+    //==========================================================================
+
+    SECTION( "files" ) {
+        REQUIRE( STONEYVCV_LFO_HPP_INCLUDED == 1 );
+    }
+
+    //==========================================================================
+
+    SECTION( "LFOModule" ) {
+        SECTION( "statics" ) {
+            REQUIRE( ::StoneyDSP::StoneyVCV::LFO::LFOModule::PARAMS_LEN == spec.get()->NUM_PARAMS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::LFO::LFOModule::INPUTS_LEN == spec.get()->NUM_INPUTS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::LFO::LFOModule::OUTPUTS_LEN == spec.get()->NUM_OUTPUTS );
+            REQUIRE( ::StoneyDSP::StoneyVCV::LFO::LFOModule::LIGHTS_LEN == spec.get()->NUM_LIGHTS );
+        }
+        SECTION( "methods" ) {
+            ::StoneyDSP::StoneyVCV::LFO::LFOModule* test_lfoModule = new ::StoneyDSP::StoneyVCV::LFO::LFOModule;
+            REQUIRE( test_lfoModule->getNumParams() == spec.get()->NUM_PARAMS );
+            REQUIRE( test_lfoModule->getNumInputs() == spec.get()->NUM_INPUTS );
+            REQUIRE( test_lfoModule->getNumOutputs() == spec.get()->NUM_OUTPUTS );
+            REQUIRE( test_lfoModule->getNumLights() == spec.get()->NUM_LIGHTS );
+            delete test_lfoModule;
+        }
+    }
+
+    //==========================================================================
+
+    SECTION( "LFOModuleWidget" ) {
+        // ::StoneyDSP::StoneyVCV::LFO::LFOModule* test_lfoModule = new ::StoneyDSP::StoneyVCV::LFO::LFOModule;
+        // ::rack::app::ModuleWidget* test_lfoModuleWidget = new ::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget(dynamic_cast<::StoneyDSP::StoneyVCV::LFO::LFOModule*>(test_lfoModule));
+        // std::shared_ptr<::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget> test_lfoModuleWidget = std::make_shared<::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget>();
+        // REQUIRE( test_lfoModuleWidget.get()->box.size.x == 5.08F );
+        // REQUIRE( test_lfoModuleWidget.get()->box.size.y == 128.5F );
+        // delete test_lfoModuleWidget;
+        // delete test_lfoModule;
+
+        // REQUIRE_THAT(
+        //     test_lfoModuleWidget.box.size.x,
+        //     Catch::Matchers::WithinRel(5.08 * 3.0, 0.001)
+        // );
+
+        // REQUIRE_THAT(
+        //     test_lfoModuleWidget.box.size.y,
+        //     Catch::Matchers::WithinRel(128.5, 0.001)
+        // );
+
+
+        // ::StoneyDSP::StoneyVCV::LFO::LFOModule* test_lfoModule = NULL;
+        // test_lfoModule = dynamic_cast<::StoneyDSP::StoneyVCV::LFO::LFOModule*>(new ::StoneyDSP::StoneyVCV::LFO::LFOModule);
+        // ::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget* test_lfoModuleWidget = new ::StoneyDSP::StoneyVCV::LFO::LFOModuleWidget(test_lfoModule);
+
+        // delete test_lfoModuleWidget;
+        // delete test_lfoModule;
+    }
+
+    //==========================================================================
+
+    SECTION( "instance" ) {
+        REQUIRE( ::StoneyDSP::StoneyVCV::LFO::modelLFO != nullptr );
+        REQUIRE( ::StoneyDSP::StoneyVCV::LFO::modelLFO->slug == spec.get()->slug );
+    }
+
+    //==========================================================================
+
+    spec.reset();
+}
+
+//==============================================================================
+
+#endif
+
+//==============================================================================

--- a/test/StoneyVCV/plugin.cpp
+++ b/test/StoneyVCV/plugin.cpp
@@ -59,6 +59,9 @@ TEST_CASE("plugin", "[plugin]") {
         SECTION( "VCA" ) {
             REQUIRE(::StoneyDSP::StoneyVCV::VCA::modelVCA != nullptr);
         }
+        SECTION( "LFO" ) {
+            REQUIRE(::StoneyDSP::StoneyVCV::LFO::modelLFO != nullptr);
+        }
 #endif
 
 #if (STONEYVCV_VERSION_MAJOR >= 0) && (STONEYVCV_VERSION_MINOR >= 0) && (STONEYVCV_VERSION_PATCH >= 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Just the skeleton code for an LFO module. No actual LFO functionality at present.

The code is optionable by a combination of both `STONEYVCV_BUILD_LFO=1` and `STONEYVCV_EXPERIMENTAL=1`.

The module will later be built by default, once implemented.
