### PR TITLE
feat/doxygen

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,56 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["production"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Install VCV's Linux Deps
+        run: |
+          sudo apt-get update && sudo apt install make doxygen
+        
+      - name: Make Doxygen
+        working-directory: ${{ github.workspace }}/docs
+        run: make -j 3
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload HTML
+          path: './docs/html'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add GitHub workflow for deploying Doxygen generated code documentation to GitHub Pages.

The workflow runs on pushes to `production`, and can be run manually from the `actions` tab as well.

Unfortunately, due to how GitHub Actions and Workflows works, we need to push the file to production in order to pick up the manual-triggering functionality; the initial push may not be correct, and if so, will be fixable on a development branch before needing to be merged to production again.
