### PR TITLE
edit 'plugin.json' - remove missing modules

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -38,15 +38,6 @@
       "tags": [
         "Blank"
       ]
-    },
-    {
-      "slug": "VCA",
-      "name": "VCA",
-      "description": "Voltage-Controlled Amplifier. Supports Polyphony.",
-      "tags": [
-        "Voltage-Controlled Amplifier",
-        "Polyphonic"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removed a missing, "experimental", module from our plugin manifest.

## What is the current behavior?

StoneyVCV modules failing to show up in user library installation due to faulty plugin manifest file.

## What is the new behavior?

Removed missing modules from manifest file. Modules are loading.

## Additional context

Here is HP1 in action. Such analogue!

![Screenshot from 2024-12-13 04-01-08](https://github.com/user-attachments/assets/720dca67-d222-45d7-b0f3-714ceb59a4e3)

Actually, just measuring Fundamental LFO's width for research.