### PR TITLE
Feat/pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,34 @@ foreach(TARGET IN LISTS STONEYVCV_TARGETS)
 #[============================[Write CMake Package]============================]
 
 include(CMakePackageConfigHelpers)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/StoneyVCV.pc.in" [==[
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=/${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=/${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: Rack-SDK = 2.5.2
+Libs: -L${libdir} -lRack
+Cflags: -I${includedir}
+]==])
+
+configure_file (
+  "${CMAKE_CURRENT_BINARY_DIR}/StoneyVCV.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/StoneyVCV.pc"
+  @ONLY
+)
+
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/StoneyVCV.pc"
+    DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/StoneyDSP-StoneyVCVConfig.cmake.in" [==[
 @PACKAGE_INIT@
 

--- a/dep/StoneyDSP/CMakeLists.txt
+++ b/dep/StoneyDSP/CMakeLists.txt
@@ -291,6 +291,35 @@ message(STATUS "Linking with StoneyDSP")
 
 ]==])
 
+# Create pkgconfig file
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/StoneyDSP.pc.in" [==[
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=/${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=/${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir}
+Cflags: -I${includedir}
+]==])
+
+# Configure pkgconfig file
+configure_file (
+  "${CMAKE_CURRENT_BINARY_DIR}/StoneyDSP.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/StoneyDSP.pc"
+  @ONLY
+)
+
+# Install pkgconfig file
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/StoneyDSP.pc"
+    DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
 configure_package_config_file(
     "${CMAKE_CURRENT_BINARY_DIR}/StoneyDSPConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/share/cmake/StoneyDSPConfig.cmake"

--- a/dep/VCVRack/Rack-SDK/CMakeLists.txt
+++ b/dep/VCVRack/Rack-SDK/CMakeLists.txt
@@ -670,6 +670,35 @@ set(VCVRACK_DISABLE_USAGE_MESSAGE @VCVRACK_DISABLE_USAGE_MESSAGE@)
 
 ]==])
 
+# Create pkgconfig file
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/Rack-SDK.pc.in" [==[
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=/${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=/${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Libs: -L${libdir}
+Cflags: -I${includedir}
+]==])
+
+# Configure pkgconfig file
+configure_file (
+  "${CMAKE_CURRENT_BINARY_DIR}/Rack-SDK.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/Rack-SDK.pc"
+  @ONLY
+)
+
+# Install pkgconfig file
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/share/pkgconfig/Rack-SDK.pc"
+    DESTINATION
+    "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
 # create cmake config file
 configure_package_config_file(
     "${CMAKE_CURRENT_BINARY_DIR}/rack-sdk-config.cmake.in"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added a small routine to write simple pkgconfig files for all three packages: Rack-SDK, StoneyDSP, and StoneyVCV.

## What is the current behavior?

No pkgconfig files are generated.

## What is the new behavior?

pkgconfig files are generated and installed by CMake.

## Additional context

Mostly I'm just interested in seeing what vcpkg does with these, to be honest I have not much use for them currently otherwise...

Closes #187 