### PR TITLE
fix/windows-artefact-extension

### DIFF
--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -192,7 +192,7 @@ jobs:
     - name: upload .exe
       uses: actions/upload-artifact@v4
       with:
-        name: StoneyVCV-2.0.1-win64.sh
+        name: StoneyVCV-2.0.1-win64.exe
         path: ${{ github.workspace }}/dist/StoneyVCV-2.0.1-win64.exe
 
     - name: upload .vcvplugin


### PR DESCRIPTION
- edit '.github/workflows/windows-latest.yml' - fix artefact .exe extension

## What kind of change does this PR introduce?

Fixed build artefact file extension for Windows installer. Should be an `.exe` but due to a typo, was being uploaded as `.sh`... 

