### PR TITLE
module/HP1-HP2-HP4

### DIFF
--- a/include/StoneyVCV/plugin.hpp
+++ b/include/StoneyVCV/plugin.hpp
@@ -190,6 +190,10 @@ namespace Panels {
 extern ::NVGcolor bgBlack;
 extern ::NVGcolor bgWhite;
 extern ::NVGcolor borderColor;
+extern ::NVGcolor bgGradientBlackS0;
+extern ::NVGcolor bgGradientBlackS1;
+extern ::NVGcolor bgGradientWhiteS0;
+extern ::NVGcolor bgGradientWhiteS1;
 extern ::StoneyDSP::float_t MIN_WIDTH;
 extern ::StoneyDSP::float_t MIN_HEIGHT;
 

--- a/src/StoneyVCV/HP1.cpp
+++ b/src/StoneyVCV/HP1.cpp
@@ -132,12 +132,14 @@ void ::StoneyDSP::StoneyVCV::HP1::HP1Widget::draw(const ::StoneyDSP::StoneyVCV::
     const auto& bgBlack = ::StoneyDSP::StoneyVCV::Panels::bgBlack;
     const auto& bgWhite = ::StoneyDSP::StoneyVCV::Panels::bgWhite;
     const auto& bgColor = ::rack::settings::preferDarkPanels ? bgBlack : bgWhite;
+    const auto& bgGradientS0 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS0 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS0;
+    const auto& bgGradientS1 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS1 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS1;
     const auto& borderColor = ::StoneyDSP::StoneyVCV::Panels::borderColor;
     const auto& minWidth = ::StoneyDSP::StoneyVCV::Panels::MIN_WIDTH;
     const auto& minHeight = ::StoneyDSP::StoneyVCV::Panels::MIN_HEIGHT;
     const auto& size = this->getSize();
 
-    // draw Themed BG
+    // Draw Themed BG
     ::nvgBeginPath(args.vg);
     ::nvgRect(args.vg,
         /** x */0.0F,
@@ -146,6 +148,25 @@ void ::StoneyDSP::StoneyVCV::HP1::HP1Widget::draw(const ::StoneyDSP::StoneyVCV::
         /** h */size.y
         );
     ::nvgFillColor(args.vg, bgColor);
+    ::nvgFill(args.vg);
+
+    // Draw themed BG gradient
+    const auto& bgGradient = ::nvgLinearGradient(args.vg,
+        size.x * 0.5,
+        0.0F,
+        size.x * 0.5,
+        380.0F,
+        bgGradientS0,
+        bgGradientS1
+    );
+    ::nvgBeginPath(args.vg);
+    ::nvgRect(args.vg,
+        /** x */0.0F,
+        /** y */0.0F,
+        /** w */size.x,
+        /** h */size.y
+        );
+    ::nvgFillPaint(args.vg, bgGradient);
     ::nvgFill(args.vg);
 
     // Draw line

--- a/src/StoneyVCV/HP2.cpp
+++ b/src/StoneyVCV/HP2.cpp
@@ -134,12 +134,14 @@ void ::StoneyDSP::StoneyVCV::HP2::HP2Widget::draw(const ::StoneyDSP::StoneyVCV::
     const auto& bgBlack = ::StoneyDSP::StoneyVCV::Panels::bgBlack;
     const auto& bgWhite = ::StoneyDSP::StoneyVCV::Panels::bgWhite;
     const auto& bgColor = ::rack::settings::preferDarkPanels ? bgBlack : bgWhite;
+    const auto& bgGradientS0 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS0 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS0;
+    const auto& bgGradientS1 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS1 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS1;
     const auto& borderColor = ::StoneyDSP::StoneyVCV::Panels::borderColor;
     const auto& minWidth = ::StoneyDSP::StoneyVCV::Panels::MIN_WIDTH;
     const auto& minHeight = ::StoneyDSP::StoneyVCV::Panels::MIN_HEIGHT;
     const auto& size = this->getSize();
 
-    // draw Themed BG
+    // Draw Themed BG
     ::nvgBeginPath(args.vg);
     ::nvgRect(args.vg,
         /** x */0.0F,
@@ -148,6 +150,25 @@ void ::StoneyDSP::StoneyVCV::HP2::HP2Widget::draw(const ::StoneyDSP::StoneyVCV::
         /** h */size.y
         );
     ::nvgFillColor(args.vg, bgColor);
+    ::nvgFill(args.vg);
+
+    // Draw themed BG gradient
+    const auto& bgGradient = ::nvgLinearGradient(args.vg,
+        size.x * 0.5,
+        0.0F,
+        size.x * 0.5,
+        380.0F,
+        bgGradientS0,
+        bgGradientS1
+    );
+    ::nvgBeginPath(args.vg);
+    ::nvgRect(args.vg,
+        /** x */0.0F,
+        /** y */0.0F,
+        /** w */size.x,
+        /** h */size.y
+        );
+    ::nvgFillPaint(args.vg, bgGradient);
     ::nvgFill(args.vg);
 
     // Draw line L

--- a/src/StoneyVCV/HP4.cpp
+++ b/src/StoneyVCV/HP4.cpp
@@ -132,12 +132,14 @@ void ::StoneyDSP::StoneyVCV::HP4::HP4Widget::draw(const ::StoneyDSP::StoneyVCV::
     const auto& bgBlack = ::StoneyDSP::StoneyVCV::Panels::bgBlack;
     const auto& bgWhite = ::StoneyDSP::StoneyVCV::Panels::bgWhite;
     const auto& bgColor = ::rack::settings::preferDarkPanels ? bgBlack : bgWhite;
+    const auto& bgGradientS0 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS0 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS0;
+    const auto& bgGradientS1 = ::rack::settings::preferDarkPanels ? ::StoneyDSP::StoneyVCV::Panels::bgGradientBlackS1 : ::StoneyDSP::StoneyVCV::Panels::bgGradientWhiteS1;
     const auto& borderColor = ::StoneyDSP::StoneyVCV::Panels::borderColor;
     const auto& minWidth = ::StoneyDSP::StoneyVCV::Panels::MIN_WIDTH;
     const auto& minHeight = ::StoneyDSP::StoneyVCV::Panels::MIN_HEIGHT;
     const auto& size = this->getSize();
 
-    // draw Themed BG
+    // Draw Themed BG
     ::nvgBeginPath(args.vg);
     ::nvgRect(args.vg,
         /** x */0.0F,
@@ -146,6 +148,25 @@ void ::StoneyDSP::StoneyVCV::HP4::HP4Widget::draw(const ::StoneyDSP::StoneyVCV::
         /** h */size.y
         );
     ::nvgFillColor(args.vg, bgColor);
+    ::nvgFill(args.vg);
+
+    // Draw themed BG gradient
+    const auto& bgGradient = ::nvgLinearGradient(args.vg,
+        size.x * 0.5,
+        0.0F,
+        size.x * 0.5,
+        380.0F,
+        bgGradientS0,
+        bgGradientS1
+    );
+    ::nvgBeginPath(args.vg);
+    ::nvgRect(args.vg,
+        /** x */0.0F,
+        /** y */0.0F,
+        /** w */size.x,
+        /** h */size.y
+        );
+    ::nvgFillPaint(args.vg, bgGradient);
     ::nvgFill(args.vg);
 
     // Draw line L

--- a/src/StoneyVCV/plugin.cpp
+++ b/src/StoneyVCV/plugin.cpp
@@ -136,6 +136,10 @@ namespace Panels {
 ::NVGcolor bgBlack = ::nvgRGBA(43, 43, 43, 255);
 ::NVGcolor bgWhite = ::nvgRGBA(235, 235, 235, 255);
 ::NVGcolor borderColor = nvgRGBAf(0.5F, 0.5F, 0.5F, 0.5F);
+::NVGcolor bgGradientBlackS0 = ::nvgRGB(42, 42, 43);
+::NVGcolor bgGradientBlackS1 = ::nvgRGB(23, 23, 23);
+::NVGcolor bgGradientWhiteS0 = ::nvgRGB(235, 235, 235);
+::NVGcolor bgGradientWhiteS1 = ::nvgRGB(225, 225, 225);
 ::StoneyDSP::float_t MIN_WIDTH = ::rack::window::mm2px(5.079999999F);
 ::StoneyDSP::float_t MIN_HEIGHT = ::rack::window::mm2px(128.693333312F);
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- adds the sexy themed 2-stop linear gradient to the panel background widgets as from Fundamental, but natively with nanoVG

Naturally, this will soon break away into the design system component. For now, it's still module-related.

Note: the VCA module does *not* have any gradient applied, while the x3 blank panels *do*, and as shown, I've just copied the gradients from Fundamental for now :smile: : 

![Screenshot from 2024-12-23 03-16-26](https://github.com/user-attachments/assets/9bd7b249-0dd5-4b43-ba98-0e20e7208bb7)
![Screenshot from 2024-12-23 03-16-12](https://github.com/user-attachments/assets/678091a0-aaba-45b5-aba8-324570f3aff9)
![Screenshot from 2024-12-23 03-15-57](https://github.com/user-attachments/assets/2dd95c3c-5934-4539-99ee-88398e9a9f03)
![Screenshot from 2024-12-23 03-15-40](https://github.com/user-attachments/assets/9941c10c-398c-442f-ac3b-81618c72223c)
 