### PR TITLE
docs/fetch-branch-commit-counts-as-module-version-numbers

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,8 +42,11 @@ jobs:
 
     steps:
 
-      - name: Checkout
+      - name: checkout StoneyVCV
         uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
 
       - name: Install VCV's Linux Deps
         run: |


### PR DESCRIPTION
# fetch branch commit counts as module versions for docs.

## What kind of change does this PR introduce?

Setting fetch-depth to 0 when checking out the project in CI runs ensures that *all* branches are pulled in during the run.

We need this, because currently, module version numbers are tied to commit counts on their respective `module/*` branches... currently!

```yml
    - name: checkout StoneyVCV
      uses: actions/checkout@v4
      with:
        submodules: true
        fetch-depth: 0
```

## What is the current behavior?

All module versions are set to `2.0.0` on this workflow run because it only checks out a single commit, thus the commit counts are not populated as expected, 

## What is the new behavior?

All modules will have build version numbers tied to the number of commits on their respective branches. This is already in production, but will also be reflected correctly in the documentation now.

